### PR TITLE
Add mattermost support

### DIFF
--- a/src/main/java/com/github/guru/qa/allure/notifications/client/clients/ClientFactory.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/client/clients/ClientFactory.java
@@ -8,6 +8,7 @@ public class ClientFactory {
         switch (messenger) {
             case telegram: return new TelegramClient();
             case slack: return new SlackClient();
+            case mattermost: return new MattermostClient();
             default: throw new IllegalArgumentException("Unknown messenger " + messenger);
         }
     }

--- a/src/main/java/com/github/guru/qa/allure/notifications/client/clients/MattermostClient.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/client/clients/MattermostClient.java
@@ -1,0 +1,53 @@
+package com.github.guru.qa.allure.notifications.client.clients;
+
+import com.github.guru.qa.allure.notifications.chart.Chart;
+import com.github.guru.qa.allure.notifications.client.Notifier;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.guru.qa.allure.notifications.message.Text.formattedMessage;
+import static com.github.guru.qa.allure.notifications.utils.SettingsHelper.*;
+import static io.restassured.RestAssured.given;
+import static java.util.Collections.singletonList;
+
+public class MattermostClient implements Notifier {
+    Map<String, Object> body = new HashMap<>();
+
+    @Override
+    public void sendText() {
+        body.put("channel_id", chatId());
+        body.put("message", formattedMessage());
+        // @formatter: off
+        given()
+            .log().body()
+            .header("Authorization", "Bearer " + botToken())
+            .body(body)
+        .when()
+            .post("https://" + apiUrl() + "/api/v4/posts")
+        .then()
+            .log().body();
+        // @formatter: on
+    }
+
+    @Override
+    public void sendPhoto() {
+        Chart.createChart();
+        // @formatter: off
+        String chartImageId =
+                given()
+                    .header("Authorization", "Bearer " + botToken())
+                    .queryParam("channel_id", chatId())
+                    .queryParam("filename", "piechart")
+                    .multiPart("piechart", new File("piechart.png"))
+                .when()
+                    .post("https://" + apiUrl() + "/api/v4/files")
+                .then()
+                    .extract().jsonPath().getList("file_infos.id").get(0).toString();
+
+        body.put("file_ids", singletonList(chartImageId));
+        sendText();
+        // @formatter: on
+    }
+}

--- a/src/main/java/com/github/guru/qa/allure/notifications/client/clients/MattermostClient.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/client/clients/MattermostClient.java
@@ -25,7 +25,7 @@ public class MattermostClient implements Notifier {
             .header("Authorization", "Bearer " + botToken())
             .body(body)
         .when()
-            .post("https://" + apiUrl() + "/api/v4/posts")
+            .post("https://" + mattermostApiUrl() + "/api/v4/posts")
         .then()
             .log().body();
         // @formatter: on
@@ -42,7 +42,7 @@ public class MattermostClient implements Notifier {
                     .queryParam("filename", "piechart")
                     .multiPart("piechart", new File("piechart.png"))
                 .when()
-                    .post("https://" + apiUrl() + "/api/v4/files")
+                    .post("https://" + mattermostApiUrl() + "/api/v4/files")
                 .then()
                     .extract().jsonPath().getList("file_infos.id").get(0).toString();
 

--- a/src/main/java/com/github/guru/qa/allure/notifications/config/Settings.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/config/Settings.java
@@ -19,6 +19,6 @@ public interface Settings extends Config {
     @Key("messenger")
     @DefaultValue("telegram")
     Messenger messenger();
-    @Key("api.url")
-    String apiUrl();
+    @Key("mattermost.api.url")
+    String mattermostApiUrl();
 }

--- a/src/main/java/com/github/guru/qa/allure/notifications/config/Settings.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/config/Settings.java
@@ -19,4 +19,6 @@ public interface Settings extends Config {
     @Key("messenger")
     @DefaultValue("telegram")
     Messenger messenger();
+    @Key("api.url")
+    String apiUrl();
 }

--- a/src/main/java/com/github/guru/qa/allure/notifications/config/enums/Messenger.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/config/enums/Messenger.java
@@ -2,5 +2,6 @@ package com.github.guru.qa.allure.notifications.config.enums;
 
 public enum Messenger {
     telegram,
-    slack
+    slack,
+    mattermost
 }

--- a/src/main/java/com/github/guru/qa/allure/notifications/utils/SettingsHelper.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/utils/SettingsHelper.java
@@ -29,6 +29,10 @@ public class SettingsHelper {
         return readSettings().messenger();
     }
 
+    public static String apiUrl() {
+        return readSettings().apiUrl();
+    }
+
     private static Settings readSettings() {
         return ConfigFactory.newInstance().create(Settings.class);
     }

--- a/src/main/java/com/github/guru/qa/allure/notifications/utils/SettingsHelper.java
+++ b/src/main/java/com/github/guru/qa/allure/notifications/utils/SettingsHelper.java
@@ -29,8 +29,8 @@ public class SettingsHelper {
         return readSettings().messenger();
     }
 
-    public static String apiUrl() {
-        return readSettings().apiUrl();
+    public static String mattermostApiUrl() {
+        return readSettings().mattermostApiUrl();
     }
 
     private static Settings readSettings() {


### PR DESCRIPTION
Добавлена поддержка Mattermost уведомлений, Issue #26 
Добавлен новый ключ `@Key("api.url")` для функционирования API, пример `http://your-mattermost-url.com/api/v4/posts` `http://${api.url}/api/v4/posts`