### PR TITLE
fixed legend for percentage of failed tests in Results message

### DIFF
--- a/src/main/java/guru/qa/allure/notifications/message/MessageData.java
+++ b/src/main/java/guru/qa/allure/notifications/message/MessageData.java
@@ -41,7 +41,7 @@ public class MessageData {
         phrases.put("totalUnknown", LANG.getPhrase("totalUnknown"));
         phrases.put("totalSkipped", LANG.getPhrase("totalSkipped"));
         phrases.put("ofPassedTests", LANG.getPhrase("ofPassedTests"));
-        phrases.put("ofFailedTests", LANG.getPhrase("ofPassedTests"));
+        phrases.put("ofFailedTests", LANG.getPhrase("ofFailedTests"));
         phrases.put("reportAvailableByLink", LANG.getPhrase("reportAvailableByLink"));
         LOG.info("Done.");
         return phrases;


### PR DESCRIPTION
In the Results message for percentage of failed tests incorrect legend fixed

![image](https://user-images.githubusercontent.com/22319051/124267548-12d15d00-db41-11eb-900c-9fc2ab7c7a4a.png)
