### PR TITLE
Make `reportLink` configiration parameter optional for e-mails

### DIFF
--- a/src/main/resources/templates/htmlMail.ftl
+++ b/src/main/resources/templates/htmlMail.ftl
@@ -11,5 +11,5 @@
     <br/><#if skipped != 0 ><b>${totalSkipped}:</b> ${skipped} </#if>
     <br/> <#if passedPercentage != 0 ><b>% ${ofPassedTests}:</b> ${passedPercentage} </#if>
     <br/><#if failedPercentage != 0 ><b>% ${ofFailedTests}:</b> ${failedPercentage} </#if>
-    <br/> <b>${reportAvailableAtLink}:</b> <a href=${reportLink}>${reportLink}</a>
+    <#if reportLink??><br/> <b>${reportAvailableAtLink}:</b> <a href=${reportLink}>${reportLink}</a></#if>
 </#compress>


### PR DESCRIPTION
These changes are addition to #100. The cause is merge of the PRs with conflicting changes: #96 and #100.