### PR TITLE
[CI] Disable fail-fast in build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         java: [8, 11, 17]
+      fail-fast: false
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This option is needed to be disabled to collect information on failures from all platforms. Otherwise the first failure cancels the executions at all other JDK versions.