### PR TITLE
Fix Gradle deprecations: do not use `java` plugin conventions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,9 @@ allprojects {
 subprojects {
     apply plugin: 'java-library'
 
-    sourceCompatibility = 1.8
+    java {
+        sourceCompatibility = 1.8
+    }
 
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'


### PR DESCRIPTION
https://docs.gradle.org/8.10.1/userguide/upgrading_version_8.html#java_convention_deprecation