### PR TITLE
Migrate to Jakarat Mail 2.1

### DIFF
--- a/allure-notifications-api/build.gradle
+++ b/allure-notifications-api/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation('org.slf4j:slf4j-api')
 
     api('com.konghq:unirest-java:3.14.5')
-    implementation('com.sun.mail:jakarta.mail:2.0.1')
+    implementation('jakarta.mail:jakarta.mail-api:2.1.3')
+    implementation('org.eclipse.angus:angus-mail:2.0.3')
     implementation('org.freemarker:freemarker:2.3.33')
     implementation('org.knowm.xchart:xchart:3.8.8')
     implementation('com.jayway.jsonpath:json-path:2.9.0')


### PR DESCRIPTION
https://jakartaee.github.io/mail-api/:
> August 18, 2021 - Jakarta Mail implementation moves to Eclipse Angus To break tight integration between Jakarta Mail Specification API and the implementation, sources of the implementation were moved to the new project - Eclipse Angus - and further development continues there. Eclipse Angus is the direct successor of JavaMail/JakartaMail.