### PR TITLE
Use dependency supporting SMTP protocol only

### DIFF
--- a/allure-notifications-api/build.gradle
+++ b/allure-notifications-api/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     api('com.konghq:unirest-java:3.14.5')
     implementation('jakarta.mail:jakarta.mail-api:2.1.3')
-    implementation('org.eclipse.angus:angus-mail:2.0.3')
+    implementation('org.eclipse.angus:smtp:2.0.3')
     implementation('org.freemarker:freemarker:2.3.33')
     implementation('org.knowm.xchart:xchart:3.8.8')
     implementation('com.jayway.jsonpath:json-path:2.9.0')


### PR DESCRIPTION
`angus-mail` dependency include the SMTP, IMAP, and POP3 protocol providers and java.util.logging handler, but only SMTP protocol is used.