### PR TITLE
telegram notification can be sent to topic inside chat

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -67,6 +67,7 @@ Example of a notification in Telegram
   "telegram": {
     "token": "",
     "chat": "",
+    "topic": "",
     "replyTo": "",
     "templatePath": "/templates/telegram.ftl"
   },
@@ -127,6 +128,13 @@ Example of a notification in Telegram
   }
 }
 ```
+
+The `telegram` block parameters:
+
++ `topic` - optional parameter defines topic id in chat to send message,
+  check [stackoverflow](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat) to get
+  parameter value
+
 The `proxy` block is used if you need to specify additional proxy configuration.\
 The `templatePath` parameter is optional and allows to set the path to custom Freemarker template for notification message.\
 Example:

--- a/README.en.md
+++ b/README.en.md
@@ -129,12 +129,6 @@ Example of a notification in Telegram
 }
 ```
 
-The `telegram` block parameters:
-
-+ `topic` - optional parameter defines topic id in chat to send message,
-  check [stackoverflow](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat) to get
-  parameter value
-
 The `proxy` block is used if you need to specify additional proxy configuration.\
 The `templatePath` parameter is optional and allows to set the path to custom Freemarker template for notification message.\
 Example:
@@ -198,3 +192,15 @@ Note:
 
 + by the time of execution the `summary.json` file should already be generated.
 + in the command-line text you need to specify the version of the `jar` file that you downloaded in the previous steps.
+
+## Messenger configurations
++ <details>
+    <summary>Telegram config</summary>
+    The `telegram` block parameters:
+    <ul>
+      <li><code>topic</code> - optional parameter defining unique identifier for the target message thread (topic) of
+        the chat to send the message to; check [Stackoverflow answers](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat)
+        to find out how to get the parameter value.
+      </li>
+    </ul>
+  </details>

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Languages: 🇬🇧 🇫🇷 🇷🇺 🇺🇦 🇧🇾 🇨🇳
   "telegram": {
     "token": "",
     "chat": "",
+    "topic": "",
     "replyTo": "",
     "templatePath": "/templates/telegram.ftl"
   },
@@ -259,6 +260,8 @@ java "-DconfigFile=notifications/config.json" -jar ../allure-notifications-4.2.1
 
 ## Особенности заполнения файла config.json в зависимости от выбранного мессенджера
 + <a href="https://github.com/qa-guru/knowledge-base/wiki/11.-Телеграм-бот.-Отправляем-уведомления-о-результатах-прохождения-тестов" target="_blank">Telegram config</a>
+  + `topic` - необязательный параметр для отправки сообщений в топик в чате. один из вариантов получения описан
+    на [stackoverflow](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat)
 + <a href="https://github.com/qa-guru/allure-notifications/wiki/Slack-configuration" target="_blank">Slack config</a>
 + <a href="https://github.com/qa-guru/allure-notifications/wiki/Email-configuration" target="_blank">Email config</a>
 + <a href="https://github.com/qa-guru/allure-notifications/wiki/Skype-configuration" target="_blank">Skype config</a>

--- a/README.md
+++ b/README.md
@@ -260,8 +260,13 @@ java "-DconfigFile=notifications/config.json" -jar ../allure-notifications-4.2.1
 
 ## Особенности заполнения файла config.json в зависимости от выбранного мессенджера
 + <a href="https://github.com/qa-guru/knowledge-base/wiki/11.-Телеграм-бот.-Отправляем-уведомления-о-результатах-прохождения-тестов" target="_blank">Telegram config</a>
-  + `topic` - необязательный параметр для отправки сообщений в топик в чате. один из вариантов получения описан
-    на [stackoverflow](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat)
+  + Параметры блока `telegram`:
+    <ul>
+      <li><code>topic</code> - необязательный параметр, определяющий уникальный идентификатор топика чата, в который
+        нужно отправить сообщение; посмотрите [ответы на Stackoverflow](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat),
+        чтобы узнать, как получить значение параметра.
+      </li>
+    </ul>
 + <a href="https://github.com/qa-guru/allure-notifications/wiki/Slack-configuration" target="_blank">Slack config</a>
 + <a href="https://github.com/qa-guru/allure-notifications/wiki/Email-configuration" target="_blank">Email config</a>
 + <a href="https://github.com/qa-guru/allure-notifications/wiki/Skype-configuration" target="_blank">Skype config</a>

--- a/allure-notifications-api/build.gradle
+++ b/allure-notifications-api/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation platform(group: 'org.slf4j', name: 'slf4j-bom', version: slf4jVersion)
     implementation('org.slf4j:slf4j-api')
 
-    api('com.konghq:unirest-java:3.14.5')
+    api("com.konghq:unirest-java:${unirestVersion}")
     implementation('jakarta.mail:jakarta.mail-api:2.1.3')
     runtimeOnly('org.eclipse.angus:smtp:2.0.3')
     implementation('org.freemarker:freemarker:2.3.34')
@@ -21,6 +21,7 @@ dependencies {
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.11.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')
+    testImplementation "com.konghq:unirest-mocks:${unirestVersion}"
 }
 
 tasks.withType(Test).configureEach {

--- a/allure-notifications-api/src/main/java/guru/qa/allure/notifications/clients/telegram/TelegramClient.java
+++ b/allure-notifications-api/src/main/java/guru/qa/allure/notifications/clients/telegram/TelegramClient.java
@@ -21,36 +21,32 @@ public class TelegramClient implements Notifier {
     @Override
     public void sendText(MessageData messageData) throws MessagingException {
         MultipartBody bodyBuilder = Unirest.post("https://api.telegram.org/bot{token}/sendMessage")
-                .routeParam("token", telegram.getToken())
                 .header("Content-Type", ContentType.APPLICATION_FORM_URLENCODED.getMimeType())
-                .field("chat_id", telegram.getChat())
-                .field("reply_to_message_id", telegram.getReplyTo() + "")
-                .field("text", MessageTemplate.createMessageFromTemplate(messageData, telegram.getTemplatePath()))
-                .field("parse_mode", "HTML");
+                .field("text", MessageTemplate.createMessageFromTemplate(messageData, telegram.getTemplatePath()));
 
-        setTopic(bodyBuilder);
+        configureCommonParameters(bodyBuilder);
 
-        bodyBuilder.asString()
-                .getBody();
+        bodyBuilder.asString().getBody();
     }
 
     @Override
     public void sendPhoto(MessageData messageData, byte[] chartImage) throws MessagingException {
         MultipartBody bodyBuilder = Unirest.post("https://api.telegram.org/bot{token}/sendPhoto")
-                .routeParam("token", telegram.getToken())
                 .field("photo", new ByteArrayInputStream(chartImage), ContentType.IMAGE_PNG, "chart.png")
-                .field("chat_id", telegram.getChat())
-                .field("reply_to_message_id", telegram.getReplyTo())
-                .field("caption", MessageTemplate.createMessageFromTemplate(messageData, telegram.getTemplatePath()))
-                .field("parse_mode", "HTML");
+                .field("caption", MessageTemplate.createMessageFromTemplate(messageData, telegram.getTemplatePath()));
 
-        setTopic(bodyBuilder);
+        configureCommonParameters(bodyBuilder);
 
-        bodyBuilder.asString()
-                .getBody();
+        bodyBuilder.asString().getBody();
     }
 
-    private void setTopic(MultipartBody bodyBuilder) {
+    private void configureCommonParameters(MultipartBody bodyBuilder) {
+        bodyBuilder
+                .routeParam("token", telegram.getToken())
+                .field("chat_id", telegram.getChat())
+                .field("reply_to_message_id", telegram.getReplyTo())
+                .field("parse_mode", "HTML");
+
         if (this.telegram.getTopic() != null) {
             bodyBuilder.field("message_thread_id", this.telegram.getTopic());
         }

--- a/allure-notifications-api/src/main/java/guru/qa/allure/notifications/clients/telegram/TelegramClient.java
+++ b/allure-notifications-api/src/main/java/guru/qa/allure/notifications/clients/telegram/TelegramClient.java
@@ -6,6 +6,7 @@ import guru.qa.allure.notifications.exceptions.MessagingException;
 import guru.qa.allure.notifications.template.MessageTemplate;
 import guru.qa.allure.notifications.template.data.MessageData;
 import kong.unirest.ContentType;
+import kong.unirest.MultipartBody;
 import kong.unirest.Unirest;
 
 import java.io.ByteArrayInputStream;
@@ -19,27 +20,39 @@ public class TelegramClient implements Notifier {
 
     @Override
     public void sendText(MessageData messageData) throws MessagingException {
-        Unirest.post("https://api.telegram.org/bot{token}/sendMessage")
+        MultipartBody bodyBuilder = Unirest.post("https://api.telegram.org/bot{token}/sendMessage")
                 .routeParam("token", telegram.getToken())
                 .header("Content-Type", ContentType.APPLICATION_FORM_URLENCODED.getMimeType())
                 .field("chat_id", telegram.getChat())
                 .field("reply_to_message_id", telegram.getReplyTo() + "")
                 .field("text", MessageTemplate.createMessageFromTemplate(messageData, telegram.getTemplatePath()))
-                .field("parse_mode", "HTML")
-                .asString()
+                .field("parse_mode", "HTML");
+
+        setTopic(bodyBuilder);
+
+        bodyBuilder.asString()
                 .getBody();
     }
 
     @Override
     public void sendPhoto(MessageData messageData, byte[] chartImage) throws MessagingException {
-        Unirest.post("https://api.telegram.org/bot{token}/sendPhoto")
+        MultipartBody bodyBuilder = Unirest.post("https://api.telegram.org/bot{token}/sendPhoto")
                 .routeParam("token", telegram.getToken())
                 .field("photo", new ByteArrayInputStream(chartImage), ContentType.IMAGE_PNG, "chart.png")
                 .field("chat_id", telegram.getChat())
                 .field("reply_to_message_id", telegram.getReplyTo())
                 .field("caption", MessageTemplate.createMessageFromTemplate(messageData, telegram.getTemplatePath()))
-                .field("parse_mode", "HTML")
-                .asString()
+                .field("parse_mode", "HTML");
+
+        setTopic(bodyBuilder);
+
+        bodyBuilder.asString()
                 .getBody();
+    }
+
+    private void setTopic(MultipartBody bodyBuilder) {
+        if (this.telegram.getTopic() != null) {
+            bodyBuilder.field("message_thread_id", this.telegram.getTopic());
+        }
     }
 }

--- a/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/telegram/Telegram.java
+++ b/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/telegram/Telegram.java
@@ -1,6 +1,7 @@
 package guru.qa.allure.notifications.config.telegram;
 
 import com.google.gson.annotations.SerializedName;
+
 import lombok.Getter;
 import lombok.Setter;
 

--- a/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/telegram/Telegram.java
+++ b/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/telegram/Telegram.java
@@ -1,8 +1,8 @@
 package guru.qa.allure.notifications.config.telegram;
 
 import com.google.gson.annotations.SerializedName;
-
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author kadehar
@@ -10,11 +10,14 @@ import lombok.Getter;
  * Model class representing telegram settings.
  */
 @Getter
+@Setter
 public class Telegram {
     @SerializedName("token")
     private String token;
     @SerializedName("chat")
     private String chat;
+    @SerializedName("topic")
+    private String topic;
     @SerializedName("replyTo")
     private String replyTo;
     @SerializedName("templatePath")

--- a/allure-notifications-api/src/test/java/guru/qa/allure/notifications/clients/mail/EmailTests.java
+++ b/allure-notifications-api/src/test/java/guru/qa/allure/notifications/clients/mail/EmailTests.java
@@ -1,14 +1,9 @@
 package guru.qa.allure.notifications.clients.mail;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.verify;
-
-import java.util.function.Consumer;
-
+import guru.qa.allure.notifications.config.base.Base;
+import guru.qa.allure.notifications.config.mail.Mail;
+import guru.qa.allure.notifications.exceptions.MessagingException;
+import guru.qa.allure.notifications.template.data.MessageData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,19 +11,21 @@ import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import guru.qa.allure.notifications.config.base.Base;
-import guru.qa.allure.notifications.config.mail.Mail;
-import guru.qa.allure.notifications.exceptions.MessagingException;
-import guru.qa.allure.notifications.template.data.MessageData;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class EmailTests {
+public class EmailTests {
     private static final String FROM = "testFROM@gmail.com";
     private static final String TO = "testTO@gmail.com";
     private static final String CC = "testCC@gmail.com, testCC2@gmail.com";
     private static final String BCC = "testBCC@gmail.com";
     private static final String PROJECT = "LETTER PROJECT";
-    private static final String EMPTY_TEMPLATE_PATH = "/template/emptyTemplate.ftl";
+    public static final String EMPTY_TEMPLATE_PATH = "/template/emptyTemplate.ftl";
     private static final String TEXT_FROM_TEMPLATE = "for test purposes";
     private static final byte[] IMG = new byte[1];
 

--- a/allure-notifications-api/src/test/java/guru/qa/allure/notifications/clients/mail/EmailTests.java
+++ b/allure-notifications-api/src/test/java/guru/qa/allure/notifications/clients/mail/EmailTests.java
@@ -1,9 +1,14 @@
 package guru.qa.allure.notifications.clients.mail;
 
-import guru.qa.allure.notifications.config.base.Base;
-import guru.qa.allure.notifications.config.mail.Mail;
-import guru.qa.allure.notifications.exceptions.MessagingException;
-import guru.qa.allure.notifications.template.data.MessageData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,21 +16,19 @@ import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.function.Consumer;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import guru.qa.allure.notifications.config.base.Base;
+import guru.qa.allure.notifications.config.mail.Mail;
+import guru.qa.allure.notifications.exceptions.MessagingException;
+import guru.qa.allure.notifications.template.data.MessageData;
 
 @ExtendWith(MockitoExtension.class)
-public class EmailTests {
+class EmailTests {
     private static final String FROM = "testFROM@gmail.com";
     private static final String TO = "testTO@gmail.com";
     private static final String CC = "testCC@gmail.com, testCC2@gmail.com";
     private static final String BCC = "testBCC@gmail.com";
     private static final String PROJECT = "LETTER PROJECT";
-    public static final String EMPTY_TEMPLATE_PATH = "/template/emptyTemplate.ftl";
+    private static final String EMPTY_TEMPLATE_PATH = "/template/emptyTemplate.ftl";
     private static final String TEXT_FROM_TEMPLATE = "for test purposes";
     private static final byte[] IMG = new byte[1];
 

--- a/allure-notifications-api/src/test/java/guru/qa/allure/notifications/clients/telegram/TelegramClientTest.java
+++ b/allure-notifications-api/src/test/java/guru/qa/allure/notifications/clients/telegram/TelegramClientTest.java
@@ -1,0 +1,85 @@
+package guru.qa.allure.notifications.clients.telegram;
+
+import guru.qa.allure.notifications.config.telegram.Telegram;
+import guru.qa.allure.notifications.template.data.MessageData;
+import kong.unirest.MatchStatus;
+import kong.unirest.MockClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static guru.qa.allure.notifications.clients.mail.EmailTests.EMPTY_TEMPLATE_PATH;
+import static kong.unirest.HttpMethod.POST;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+class TelegramClientTest {
+
+    MockClient mock;
+    MessageData messageData;
+
+    @BeforeEach
+    void setUp() {
+        mock = MockClient.register();
+        messageData = mock(MessageData.class, RETURNS_DEEP_STUBS);
+    }
+
+    @Test
+    void topicIsSetTest() throws Exception {
+        Telegram telegram = telegram("topic");
+
+        new TelegramClient(telegram).sendText(messageData);
+
+        mock.assertThat(POST, "https://api.telegram.org/bottoken/sendMessage")
+                .hadField("message_thread_id", "topic");
+    }
+
+    @Test
+    void topicIsOptionalTest() throws Exception {
+        Telegram telegram = telegram(null);
+
+        mock.expect(POST, "https://api.telegram.org/bottoken/sendMessage")
+                .body(TelegramClientTest::hasNoMessageThreadIdParameter);
+
+        new TelegramClient(telegram).sendText(messageData);
+
+        mock.verifyAll();
+    }
+
+    @Test
+    void topicIsSetForPhotoTest() throws Exception {
+        Telegram telegram = telegram("topic");
+
+        new TelegramClient(telegram).sendPhoto(messageData, new byte[0]);
+
+        mock.assertThat(POST, "https://api.telegram.org/bottoken/sendPhoto")
+                .hadField("message_thread_id", "topic");
+    }
+
+    @Test
+    void topicIsNotSetForPhotoTest() throws Exception {
+        Telegram telegram = telegram(null);
+
+        mock.expect(POST, "https://api.telegram.org/bottoken/sendPhoto")
+                .body(TelegramClientTest::hasNoMessageThreadIdParameter);
+
+        new TelegramClient(telegram).sendPhoto(messageData, new byte[0]);
+
+        mock.verifyAll();
+    }
+
+    private static MatchStatus hasNoMessageThreadIdParameter(List<String> body) {
+        return new MatchStatus(body.stream().map(x -> x.split("=")[0]).noneMatch(x -> x.equals("message_thread_id")), "параметр не задан: " + "message_thread_id");
+    }
+
+    private static Telegram telegram(String topic) {
+        Telegram telegram = new Telegram();
+        telegram.setChat("chat");
+        telegram.setTopic(topic);
+        telegram.setToken("token");
+        telegram.setReplyTo("reply-to");
+        telegram.setTemplatePath(EMPTY_TEMPLATE_PATH);
+        return telegram;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -18,4 +18,5 @@ subprojects {
 ext {
     lombokVersion = '1.18.34'
     slf4jVersion = '2.0.16'
+    unirestVersion = '3.14.5'
 }


### PR DESCRIPTION
New optional parameter topic has been added to telegram configuration in order to send telegram notification to topic inside chat.
How to get topic id ? The answer is: [stackoverflow](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat)

second attempt based on https://github.com/qa-guru/allure-notifications/pull/308