### PR TITLE
feat: collage free-grid layout (CB-870 lossless)

### DIFF
--- a/allure-notifications-api/src/main/java/guru/qa/allure/notifications/chart/CollageRenderer.java
+++ b/allure-notifications-api/src/main/java/guru/qa/allure/notifications/chart/CollageRenderer.java
@@ -16,6 +16,7 @@ import java.util.Locale;
 
 import guru.qa.allure.notifications.config.base.Base;
 import guru.qa.allure.notifications.config.chart.ChartConfig;
+import guru.qa.allure.notifications.config.chart.ChartPanelItem;
 import guru.qa.allure.notifications.exceptions.MessageBuildException;
 import guru.qa.allure.notifications.model.legend.Legend;
 import guru.qa.allure.notifications.report.ReportAnalytics;
@@ -36,13 +37,19 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>Row layout ({@code chart.layout = "row"}): pie, pyramid, durations side by side in a single
  * horizontal row — a wide image.
+ *
+ * <p>Free layout ({@code chart.layout = "free"}): panels from {@code chart.items}
+ * ({@code type,x,y,w,h}) on a {@code gridCols × gridRows} cell grid (CB-870 lossless).
  */
 @Slf4j
 public final class CollageRenderer {
     private static final int DEFAULT_WIDTH = 1000;
     private static final int DEFAULT_HEIGHT = 600;
+    private static final int DEFAULT_GRID_COLS = 10;
+    private static final int DEFAULT_GRID_ROWS = 10;
     private static final String LAYOUT_STACKED = "stacked";
     private static final String LAYOUT_ROW = "row";
+    private static final String LAYOUT_FREE = "free";
     // Container ("card") geometry: gap around/between panels + corner radius.
     private static final int CARD_GAP = 14;
     private static final int CARD_ARC = 18;
@@ -212,7 +219,123 @@ public final class CollageRenderer {
         if (LAYOUT_ROW.equalsIgnoreCase(layout)) {
             return renderRow(base, analytics, legend, collageWidth, collageHeight, headerHeight);
         }
+        if (LAYOUT_FREE.equalsIgnoreCase(layout)) {
+            return renderFree(base, analytics, legend, collageWidth, collageHeight, headerHeight);
+        }
         return renderGrid(base, analytics, legend, collageWidth, collageHeight, headerHeight);
+    }
+
+    /**
+     * Free-grid: place each {@link ChartPanelItem} on a cell grid (default 10×10).
+     * Pixel bounds = cell slots with the same CARD_GAP / half-gap inset as {@link #renderGrid}.
+     */
+    private static byte[] renderFree(Base base, ReportAnalytics analytics, Legend legend,
+                                     int collageWidth, int collageHeight, int headerHeight)
+            throws MessageBuildException {
+        ChartConfig chartConfig = base != null ? base.getChart() : null;
+        int cols = chartConfig != null && chartConfig.getGridCols() != null && chartConfig.getGridCols() > 0
+                ? chartConfig.getGridCols()
+                : DEFAULT_GRID_COLS;
+        int rows = chartConfig != null && chartConfig.getGridRows() != null && chartConfig.getGridRows() > 0
+                ? chartConfig.getGridRows()
+                : DEFAULT_GRID_ROWS;
+        List<ChartPanelItem> items = selectedFreeItems(chartConfig);
+        int half = CARD_GAP / 2;
+        int cellW = collageWidth / cols;
+        int cellH = collageHeight / rows;
+
+        ChartTheme theme = ChartTheme.from(base);
+        BufferedImage collage = new BufferedImage(collageWidth, collageHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = collage.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setColor(outerBackground(theme));
+            graphics.fillRect(0, 0, collageWidth, collageHeight);
+
+            for (ChartPanelItem item : items) {
+                String key = normalize(item.getType());
+                if (key == null) {
+                    continue;
+                }
+                int x = clamp(item.getX(), 0, cols - 1);
+                int y = clamp(item.getY(), 0, rows - 1);
+                int w = Math.max(1, item.getW() == null ? 1 : item.getW());
+                int h = Math.max(1, item.getH() == null ? 1 : item.getH());
+                if (x + w > cols) {
+                    w = cols - x;
+                }
+                if (y + h > rows) {
+                    h = rows - y;
+                }
+
+                int rawLeft = x * cellW;
+                int rawTop = y * cellH;
+                int rawRight = (x + w) * cellW;
+                int rawBottom = (y + h) * cellH;
+                int cellLeft = x == 0 ? CARD_GAP : rawLeft + half;
+                int cellTop = y == 0 ? CARD_GAP : rawTop + half;
+                int cellRight = x + w == cols ? collageWidth - CARD_GAP : rawRight - half;
+                int cellBottom = y + h == rows ? collageHeight - CARD_GAP : rawBottom - half;
+                int cellWidth = Math.max(1, cellRight - cellLeft);
+                int cellHeight = Math.max(1, cellBottom - cellTop);
+                int bodyHeight = Math.max(1, cellHeight - headerHeight);
+                BufferedImage panel = renderPanel(key, base, cellWidth, bodyHeight, analytics, legend);
+                Rect rect = new Rect(cellLeft, cellTop, cellWidth, cellHeight);
+                drawCard(graphics, panel, rect, theme, panelTitle(key, base, analytics), headerHeight);
+            }
+        } finally {
+            graphics.dispose();
+        }
+
+        log.info("Collage chart is created ({}x{}, free, items={}, grid={}x{}).",
+                collageWidth, collageHeight, items.size(), cols, rows);
+        return ChartImageEncoder.toPngBytes(collage);
+    }
+
+    private static int clamp(Integer value, int min, int max) {
+        if (value == null) {
+            return min;
+        }
+        return Math.max(min, Math.min(max, value));
+    }
+
+    /**
+     * Valid free-grid items; falls back to CB-870-grid default when {@code items} is empty.
+     */
+    private static List<ChartPanelItem> selectedFreeItems(ChartConfig chartConfig) {
+        List<ChartPanelItem> configured = chartConfig != null ? chartConfig.getItems() : null;
+        List<ChartPanelItem> items = new ArrayList<>();
+        if (configured != null) {
+            for (ChartPanelItem raw : configured) {
+                if (raw == null || normalize(raw.getType()) == null) {
+                    continue;
+                }
+                items.add(raw);
+            }
+        }
+        if (!items.isEmpty()) {
+            return items;
+        }
+        // CB-870-grid default: pie | pyramid top 5×5, durations full-width 10×5 bottom.
+        ChartPanelItem pie = new ChartPanelItem();
+        pie.setType(PANEL_PIE);
+        pie.setX(0);
+        pie.setY(0);
+        pie.setW(5);
+        pie.setH(5);
+        ChartPanelItem pyramid = new ChartPanelItem();
+        pyramid.setType(PANEL_PYRAMID);
+        pyramid.setX(5);
+        pyramid.setY(0);
+        pyramid.setW(5);
+        pyramid.setH(5);
+        ChartPanelItem durations = new ChartPanelItem();
+        durations.setType(PANEL_DURATIONS);
+        durations.setX(0);
+        durations.setY(5);
+        durations.setW(10);
+        durations.setH(5);
+        return Arrays.asList(pie, pyramid, durations);
     }
 
     private static byte[] renderRow(Base base, ReportAnalytics analytics, Legend legend,

--- a/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/chart/ChartConfig.java
+++ b/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/chart/ChartConfig.java
@@ -12,7 +12,11 @@ import lombok.Data;
  *
  * <p>{@code panels} is a list of rows (each inner list is one horizontal row of the
  * collage grid). A flat array of ids is also accepted and treated as a single row
- * (see {@link PanelsDeserializer}).
+ * (see {@link PanelsDeserializer}). Used by {@code layout} {@code grid}/{@code stacked}/
+ * {@code row} (lossy equal columns within a row).
+ *
+ * <p>When {@code layout} is {@code free}, placements come from {@link #items} on a
+ * {@link #gridCols}×{@link #gridRows} cell grid (collage-builder CB-870 lossless path).
  */
 @Data
 public class ChartConfig {
@@ -22,6 +26,17 @@ public class ChartConfig {
     private List<List<String>> panels = Arrays.asList(
             Arrays.asList("pie", "testingPyramid"),
             Arrays.asList("statusDynamics", "successRateDistribution"));
+
+    /**
+     * Free-grid placements ({@code layout = "free"}). Ignored for legacy layouts.
+     */
+    private List<ChartPanelItem> items;
+
+    /** Cell columns for free layout (default 10 — CB-870-grid). */
+    private Integer gridCols = 10;
+
+    /** Cell rows for free layout (default 10 — CB-870-grid). */
+    private Integer gridRows = 10;
 
     private String pyramidFallback = "suites";
     private String layout = "grid";

--- a/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/chart/ChartPanelItem.java
+++ b/allure-notifications-api/src/main/java/guru/qa/allure/notifications/config/chart/ChartPanelItem.java
@@ -1,0 +1,18 @@
+package guru.qa.allure.notifications.config.chart;
+
+import lombok.Data;
+
+/**
+ * One free-grid panel placement on the collage canvas (collage-builder CB-870 cells).
+ *
+ * <p>{@code x}/{@code y}/{@code w}/{@code h} are cell coordinates on a
+ * {@code gridCols × gridRows} grid (default 10×10).
+ */
+@Data
+public class ChartPanelItem {
+    private String type;
+    private Integer x;
+    private Integer y;
+    private Integer w;
+    private Integer h;
+}

--- a/allure-notifications-api/src/test/java/guru/qa/allure/notifications/chart/CollageRendererTest.java
+++ b/allure-notifications-api/src/test/java/guru/qa/allure/notifications/chart/CollageRendererTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import guru.qa.allure.notifications.config.base.Base;
 import guru.qa.allure.notifications.config.chart.ChartConfig;
+import guru.qa.allure.notifications.config.chart.ChartPanelItem;
 import guru.qa.allure.notifications.json.JSON;
 import guru.qa.allure.notifications.model.legend.Legend;
 import guru.qa.allure.notifications.model.summary.Summary;
@@ -84,6 +85,45 @@ class CollageRendererTest {
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(chart));
         assertEquals(1000, image.getWidth());
         assertEquals(600, image.getHeight());
+    }
+
+    @Test
+    void rendersFreeLayoutCb870DefaultLossless() throws Exception {
+        Base base = collageBase();
+        ChartConfig chart = base.getChart();
+        chart.setLayout("free");
+        chart.setWidth(870);
+        chart.setHeight(1080);
+        chart.setGridCols(10);
+        chart.setGridRows(10);
+        chart.setHeaderHeight(68);
+
+        ChartPanelItem pie = new ChartPanelItem();
+        pie.setType("pie");
+        pie.setX(0);
+        pie.setY(0);
+        pie.setW(5);
+        pie.setH(5);
+        ChartPanelItem pyramid = new ChartPanelItem();
+        pyramid.setType("testingPyramid");
+        pyramid.setX(5);
+        pyramid.setY(0);
+        pyramid.setW(5);
+        pyramid.setH(5);
+        ChartPanelItem durations = new ChartPanelItem();
+        durations.setType("durations");
+        durations.setX(0);
+        durations.setY(5);
+        durations.setW(10);
+        durations.setH(5);
+        chart.setItems(java.util.Arrays.asList(pie, pyramid, durations));
+
+        byte[] png = CollageRenderer.render(base, ReportAnalyticsBuilder.build(base, summary()), legend());
+
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(png));
+        assertEquals(870, image.getWidth());
+        assertEquals(1080, image.getHeight());
+        assertTrue(hasNonBackgroundPixels(image));
     }
 
     private static Base collageBase() throws URISyntaxException {

--- a/allure-notifications-api/src/test/java/guru/qa/allure/notifications/config/chart/ChartConfigTest.java
+++ b/allure-notifications-api/src/test/java/guru/qa/allure/notifications/config/chart/ChartConfigTest.java
@@ -42,6 +42,30 @@ class ChartConfigTest {
     }
 
     @Test
+    void parsesFreeLayoutItems() throws Exception {
+        ChartConfig config = new JsonMapper().readValue(
+                "{"
+                        + "\"layout\":\"free\","
+                        + "\"gridCols\":10,"
+                        + "\"gridRows\":10,"
+                        + "\"items\":["
+                        + "{\"type\":\"pie\",\"x\":0,\"y\":0,\"w\":5,\"h\":5},"
+                        + "{\"type\":\"testingPyramid\",\"x\":5,\"y\":0,\"w\":5,\"h\":5},"
+                        + "{\"type\":\"durations\",\"x\":0,\"y\":5,\"w\":10,\"h\":5}"
+                        + "]"
+                        + "}",
+                ChartConfig.class);
+
+        assertEquals("free", config.getLayout());
+        assertEquals(Integer.valueOf(10), config.getGridCols());
+        assertEquals(3, config.getItems().size());
+        assertEquals("pie", config.getItems().get(0).getType());
+        assertEquals(Integer.valueOf(5), config.getItems().get(0).getW());
+        assertEquals("durations", config.getItems().get(2).getType());
+        assertEquals(Integer.valueOf(10), config.getItems().get(2).getW());
+    }
+
+    @Test
     void defaultPanelsAreDashboardGrid() {
         ChartConfig config = new ChartConfig();
         assertEquals(2, config.getPanels().size());

--- a/config/config.preview-cb870-free.json
+++ b/config/config.preview-cb870-free.json
@@ -1,0 +1,39 @@
+{
+  "base": {
+    "project": "CB-870-grid free dogfood",
+    "environment": "local dogfood",
+    "comment": "P2 free-grid: CB-870 default lossless items",
+    "language": "ru",
+    "allureFolder": "/Users/stanislav/zero-design-system/projects/allure-notifications-home/allure-notifications/build/pyramid-showcase/allure-report/",
+    "allureResultsFolder": "/Users/stanislav/zero-design-system/projects/allure-notifications-home/allure-notifications/build/pyramid-showcase/allure-results/",
+    "enableChart": true,
+    "darkMode": true,
+    "enableSuitesPublishing": false,
+    "chart": {
+      "mode": "collage",
+      "layout": "free",
+      "width": 870,
+      "height": 1080,
+      "headerHeight": 68,
+      "gridCols": 10,
+      "gridRows": 10,
+      "items": [
+        {"type": "pie", "x": 0, "y": 0, "w": 5, "h": 5},
+        {"type": "testingPyramid", "x": 5, "y": 0, "w": 5, "h": 5},
+        {"type": "durations", "x": 0, "y": 5, "w": 10, "h": 5}
+      ],
+      "pyramidFallback": "suites"
+    },
+    "links": {
+      "report": "https://autotests-ai.github.io/reference-app/reports/latest/awesome/index.html",
+      "dashboard": "https://autotests-ai.github.io/reference-app/reports/latest/dashboard/index.html",
+      "testops": "https://allure.autotests.cloud",
+      "build": "https://github.com/autotests-ai/reference-app/actions"
+    }
+  },
+  "telegram": {
+    "token": "0:preview-no-send",
+    "chat": "0",
+    "templatePath": "/templates/telegram.ftl"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `chart.layout: "free"` with `items: [{type,x,y,w,h}]` on a 10×10 grid so CB-870 default (5×5 | 5×5 + 10×5) exports lossless from collage-builder.
- Keep legacy `grid|stacked|row` + `panels` rows behavior unchanged (lossy equal columns).
- Tests for free-layout parse/render + local preview config `config.preview-cb870-free.json`.

## Test plan
- [ ] `:allure-notifications-api:test` (free + legacy collage cases)
- [ ] Quality gates / checkstyle / jacoco as in CI
- [ ] Dogfood: `config.preview-cb870-free.json` → PNG 870×1080 matches CB-870 spans
- [ ] Regression: rows Export (`layout: grid`, `panels`) still renders equal-column layout


Made with [Cursor](https://cursor.com)