### PR TITLE
chore(6.0): Phase 0–1 monorepo shell + packages/config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ target/
 # Local secrets — never commit real tokens
 config/*.local.json
 config/*.runtime.json
+
+# TypeScript monorepo (6.0.*)
+node_modules/
+.pnpm-store/
+packages/*/dist/
+packages/*/coverage/
+*.tsbuildinfo

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,107 @@
+# Migration: 5.0.* Java → 6.0.* TypeScript
+
+SSOT plan (workspace): `.cursor/plans/an_ts_migration_prompt_5f4be014.plan.md`  
+Hub: `projects/allure-notifications-home/`  
+Upstream: [qa-guru/allure-notifications](https://github.com/qa-guru/allure-notifications)
+
+## Versions
+
+There is **no 5.1** line. Product versions jump **5.0.\* (Java)** → **6.0.\* (TypeScript)**.
+
+| Line | Stack | Status |
+|------|-------|--------|
+| **5.0.\*** | Java Gradle fat jar (current **5.0.8**) | **Current / legacy freeze** — bugfix / security only; **no TypeScript** |
+| **6.0.\*** | TypeScript monorepo (CLI + builder + packages) | **Next line** — skeleton on `feature/6.0-phase-0-1`; not on `master` yet |
+
+Pin in monorepo docs (`docs/allure-notifications/VERSION`) stays **5.0.8** until CLI dogfood cutover. Root `package.json` version **6.0.0** marks the TS line; do not publish / cut consumers until Phase 3 dogfood.
+
+## Public product (locked)
+
+Standalone **CLI** + **web builder**. Not an Allure 3 plugin, not a Jenkins plugin, not an HTML patcher.
+
+```bash
+npx allure generate
+npx allure-notifications send --config config.json
+```
+
+| | Do |
+|--|----|
+| TS CLI post-step after `allure generate` | **yes** — main 6.0 runtime |
+| Builder on GitHub Pages | **yes** — `apps/builder/` |
+| Native collage PNG | **yes** — `packages/core` (Canvas/Sharp/Skia TBD); never Playwright for production PNG |
+| `packages/pyramid` SSOT (colors + geometry) | **yes** |
+| Thin A3 plugin wrapper | later optional (Phase 5) |
+| `dashboard-overrides` / HTML inject in npm | **no** — private zds stack / upstream Allure only |
+| Merge into `allure-framework/allure3` | **no** |
+
+## Target tree
+
+```text
+allure-notifications/                 # version line 6.0.*
+  packages/
+    config/          # zod, PANEL_CATALOG, DEFAULT_ITEMS, canvas presets
+    pyramid/         # palette + CORNER_RATIO / TIER_GAP / rounded tiers (SSOT)
+    core/            # read A3 summary/results → native collage PNG → messengers
+    cli/             # bin: allure-notifications send
+    plugin/          # optional later — thin Plugin over core
+  apps/
+    builder/         # was qa-guru/allure-notifications-builder; Pages CNAME
+  legacy/
+    java/            # 5.0.* freeze (Gradle multi-module)
+  pnpm-workspace.yaml
+  package.json       # "version": "6.0.0"
+  MIGRATION.md
+  docs/
+    ci-cookbook.md
+    phase-0-checklist.md
+```
+
+Today (pre-move): Java modules at repo root (`allure-notifications/`, `allure-notifications-api/`); builder lives in a **second** repo clone under the hub (`allure-notifications-builder/`). Phase 0 documents the moves; physical merge is gated by [docs/phase-0-checklist.md](docs/phase-0-checklist.md).
+
+## Phases
+
+| Phase | Scope | Status |
+|-------|--------|--------|
+| **0** | Monorepo shell, MIGRATION, checklist, CI sketch; no big-bang move | **done** (layout moves deferred — see phase-0-checklist) |
+| **1** | `packages/config` — zod schema, PANEL_CATALOG, DEFAULT_ITEMS, SQ-1080 presets | **done** |
+| **2** | `packages/pyramid` — palette + geometry SSOT (not dashboard-overrides) | pending |
+| **3** | `packages/core` + `cli` — native PNG, Telegram, dogfood, cookbooks; public **6.0.0** | pending |
+| **4** | Builder full TS; import `@config` / `@pyramid`; typescript@7 / tsgo in CI | pending |
+| **5** | Optional thin `@allurereport/plugin-api` wrapper over `core` | optional |
+
+## Anti-hack rules
+
+1. `npx allure-notifications send` must not touch awesome/dashboard HTML.
+2. Production PNG without Playwright.
+3. Builder + CLI share one `@config`.
+4. Pyramid numbers live in one `@pyramid`.
+5. README: 5.0 Java legacy / 6.0 TypeScript; standalone utility.
+6. Stand `:3011` + Pages stay live across the builder merge.
+
+## Out of scope
+
+- Shipping `dashboard-overrides.js` / `inject-allure-pyramid-colors.mjs` in npm
+- Merge into `allure-framework/allure3`
+- Jenkins Plugin Manager
+- collage-builder (`:3010`)
+- Allure 2 compat (unless explicitly requested later)
+- Deleting `legacy/java` before 6.0 dogfood parity
+- Big-bang rewrite without this file
+
+## CI surface (sketch)
+
+See [docs/ci-cookbook.md](docs/ci-cookbook.md): `allure generate` → `allure-notifications send`. No `java -jar` on the 6.0 path.
+
+## Phase 1 notes
+
+`@allure-notifications/config` (`packages/config/`):
+
+- zod `ConfigSchema` — `base.chart` free layout + chrome knobs (`headerHeight` / `cardGap` / `tilePad`)
+- `PANEL_CATALOG` (17), `DEFAULT_ITEMS` (SQ-1080 7-tile), `CANVAS_PRESETS` (870/1080/1410×1080), `createDefaultConfig()`
+- Extracted from hub builder `allure-notifications-builder/js/app.js` (builder still has a local copy until Phase 4 / `apps/builder/` merge)
+- Verify: `pnpm --filter @allure-notifications/config test`
+
+## Next
+
+**Phase 2** — `packages/pyramid` (palette + `CORNER_RATIO` / `TIER_GAP` geometry SSOT; not `dashboard-overrides`).
+Ask before starting Phase 2.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,11 @@
+# apps/
+
+Application packages for line **6.0.\***.
+
+| App | Role | Phase |
+|-----|------|-------|
+| `builder/` | Web `config.json` configurator (merge from `allure-notifications-builder`) | 0 checklist → merge |
+
+Until the merge checklist is executed, the live builder remains the hub clone `projects/allure-notifications-home/allure-notifications-builder/` (stand `:3011`).
+
+See [../docs/phase-0-checklist.md](../docs/phase-0-checklist.md).

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -1,0 +1,74 @@
+# CI cookbook sketch (6.0 TypeScript)
+
+Target public surface after Phase 3. **Not** runnable end-to-end until `packages/cli` ships. Java `java -jar` remains the 5.0 path under `legacy/java/`.
+
+## Contract
+
+1. Generate Allure 3 report (or ensure `allure-report/` exists).
+2. Run **allure-notifications** as a separate post-step with `config.json`.
+3. CLI reads report artifacts / summary → native collage PNG → messenger(s).
+4. CLI does **not** patch awesome/dashboard HTML.
+
+```bash
+npx allure generate
+npx allure-notifications send --config config.json
+```
+
+## GitHub Actions (sketch)
+
+```yaml
+# .github/workflows/notify.yml — sketch only
+name: allure-notifications
+on:
+  workflow_run:
+    workflows: [tests]
+    types: [completed]
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # … restore allure-results / generate report …
+      - name: Generate Allure report
+        run: npx allure generate allure-results --clean -o allure-report
+      - name: Send notifications
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT: ${{ secrets.TELEGRAM_CHAT }}
+        run: npx allure-notifications send --config config/notifications.json
+```
+
+## Jenkins (sketch)
+
+Freestyle / Pipeline — two shell steps after tests (same as GH):
+
+```groovy
+// Pipeline fragment — sketch only
+stage('Allure report') {
+  steps {
+    sh 'npx allure generate allure-results --clean -o allure-report'
+  }
+}
+stage('Notifications') {
+  steps {
+    withCredentials([string(credentialsId: 'telegram-token', variable: 'TELEGRAM_TOKEN')]) {
+      sh 'npx allure-notifications send --config config/notifications.json'
+    }
+  }
+}
+```
+
+## Explicit non-goals (this cookbook)
+
+| Avoid | Why |
+|-------|-----|
+| `java -jar allure-notifications-*.jar` on 6.0 path | Legacy 5.0 only (`legacy/java/`) |
+| Jenkins Plugin Manager install | Not a Jenkins plugin |
+| Allure 3 plugin install for notify | CLI is the entrypoint; optional thin plugin = Phase 5 |
+| HTML inject / `dashboard-overrides` in CI | Private zds stack only — not npm product |
+
+## Config
+
+Use builder export (`apps/builder/` after merge) → `config.json` with free layout (`chart.layout: "free"`, `items`). Default canvas target: **SQ-1080**.

--- a/docs/phase-0-checklist.md
+++ b/docs/phase-0-checklist.md
@@ -1,0 +1,62 @@
+# Phase 0 checklist — merge + legacy layout
+
+Do **not** execute big moves until this checklist is explicitly OK'd. Phase 0 = document + skeleton only.
+
+## Layout moves (deferred)
+
+| # | Action | From | To | Done |
+|---|--------|------|-----|------|
+| 1 | Move Gradle multi-module tree under legacy | repo-root modules (`allure-notifications/`, `allure-notifications-api/`, `build.gradle`, `settings.gradle`, `gradle/`, `gradlew*`) | `legacy/java/` (keep build runnable from that cwd) | [ ] |
+| 2 | README legacy banner | root README | State **5.0.\* Java legacy** / **6.0.\* TypeScript** active; point jar users at `legacy/java/` | [ ] |
+| 3 | Merge builder into monorepo | hub clone `allure-notifications-builder/` (or upstream Pages repo) | `apps/builder/` | [ ] |
+| 4 | Archive second repo | `qa-guru/allure-notifications-builder` | Archive on GitHub after Pages points at `apps/builder/` | [ ] |
+| 5 | Pages CNAME / custom domain | builder Pages (`allure.notifications.qa.guru`) | Serve from `apps/builder/` (same CNAME / GH Pages source) | [ ] |
+| 6 | Stand registry cwd | `projects/allure-notifications-home/allure-notifications-builder` | `projects/allure-notifications-home/allure-notifications/apps/builder` | [ ] |
+| 7 | Hub README bootstrap | clone two repos | clone one `allure-notifications`; builder path = `apps/builder/` | [ ] |
+
+## Stand `:3011`
+
+Current (`scripts/stands/registry.json`):
+
+- id: `allure-notifications-builder`
+- port: `3011`
+- cwd: `projects/allure-notifications-home/allure-notifications-builder`
+- cmd: `python -m http.server 3011`
+
+After merge:
+
+```json
+"cwd": "projects/allure-notifications-home/allure-notifications/apps/builder"
+```
+
+Validate only via:
+
+```bash
+python scripts/stands/ensure.py allure-notifications-builder
+curl -sf -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3011/
+```
+
+Do **not** kill/restart the stand while this chat is active unless the user asks to «погаси».
+
+## pnpm skeleton (Phase 0 — done when files exist)
+
+| # | File | Done |
+|---|------|------|
+| 1 | Root `package.json` (`name`, `version` 6.0.0, `private`) | [x] |
+| 2 | `pnpm-workspace.yaml` → `packages/*`, `apps/*` | [x] |
+| 3 | `packages/config` minimal stub | [x] |
+| 4 | Empty package dirs for later phases (optional stubs) | [ ] pyramid / core / cli — Phase 1+ |
+
+## Must not break during moves
+
+- Java jar build still works under `legacy/java/` until 6.0 dogfood parity
+- Builder Playwright tests / dogfood scripts relocate with `apps/builder/`
+- Monorepo pin `docs/allure-notifications/VERSION` stays **5.0.8** until cutover
+- No `dashboard-overrides` / inject copied into `packages/`
+
+## Sign-off
+
+| Gate | Owner | OK |
+|------|-------|----|
+| Execute layout moves (rows 1–7) | user | [ ] |
+| Start Phase 1 `packages/config` | user | [ ] |

--- a/docs/phase-1-checklist.md
+++ b/docs/phase-1-checklist.md
@@ -1,0 +1,15 @@
+# Phase 1 checklist — packages/config
+
+| # | Item | Done |
+|---|------|------|
+| 1 | zod `ConfigSchema` for `config.json` (free + chrome knobs) | [x] |
+| 2 | Extract `PANEL_CATALOG` (17), `DEFAULT_ITEMS`, `CANVAS_PRESETS` | [x] |
+| 3 | `createDefaultConfig()` / SQ-1080 defaults (`headerHeight` 22, `cardGap` 14, `tilePad` 6) | [x] |
+| 4 | Tests: default export + repo fixtures validate | [x] |
+| 5 | Wire builder to import `@allure-notifications/config` | [ ] Phase 4 (after `apps/builder/` merge) |
+
+```bash
+cd projects/allure-notifications-home/allure-notifications
+pnpm install
+pnpm --filter @allure-notifications/config test
+```

--- a/package.json
+++ b/package.json
@@ -1,10 +1,22 @@
 {
+  "name": "allure-notifications",
+  "version": "6.0.0",
+  "private": true,
+  "description": "Allure report \u2192 messenger notifications. 6.0.* = TypeScript monorepo (CLI + builder). 5.0.* = Java jar (current master); there is no 5.1 line.",
+  "packageManager": "pnpm@9.15.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
   "changelog": {
     "labels": {
       "other": "New Feature",
       "fix": "Bug Fix",
       "refactor": "Refactoring"
     },
-    "repo": "username/repo"
+    "repo": "qa-guru/allure-notifications"
   }
 }

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,13 @@
+# packages/
+
+TypeScript workspace packages for line **6.0.\***.
+
+| Package | Role | Phase |
+|---------|------|-------|
+| [`config`](config/) | zod schema, PANEL_CATALOG, DEFAULT_ITEMS, canvas presets | **1 done** |
+| `pyramid` | palette + rounded-tier geometry SSOT | 2 |
+| `core` | report → native PNG → messengers | 3 |
+| `cli` | `allure-notifications send` | 3 |
+| `plugin` | optional thin Allure 3 plugin over `core` | 5 |
+
+See [../MIGRATION.md](../MIGRATION.md).

--- a/packages/config/.gitignore
+++ b/packages/config/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,17 @@
+# @allure-notifications/config
+
+Shared **config.json** schema + builder catalog / canvas presets for line **6.0.\***.
+
+| Export | Role |
+|--------|------|
+| `ConfigSchema` / `parseConfig` | zod validation (free layout + chrome knobs) |
+| `PANEL_CATALOG` / `resolvePanelMeta` | 17 palette slots |
+| `DEFAULT_ITEMS` / `CANVAS_PRESETS` / `createDefaultConfig` | SQ-1080 canon + 870/1080/1410 presets |
+
+Chrome defaults (builder SQ-1080): `headerHeight` **22**, `cardGap` **14**, `tilePad` **6**.
+
+```bash
+pnpm --filter @allure-notifications/config test
+```
+
+Source extracted from hub builder `allure-notifications-builder/js/app.js` (Phase 0 — builder not yet merged to `apps/builder/`). Phase 4 wires builder imports.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@allure-notifications/config",
+  "version": "6.0.0",
+  "private": true,
+  "description": "Shared config schema + PANEL_CATALOG / DEFAULT_ITEMS / canvas presets (Phase 1).",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm run build && node --test dist/test/*.test.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "typescript": "^5.8.2"
+  }
+}

--- a/packages/config/src/catalog.ts
+++ b/packages/config/src/catalog.ts
@@ -1,0 +1,194 @@
+/**
+ * Panel catalog extracted from allure-notifications-builder `js/app.js`.
+ * 17 slots ↔ awesome-charts / ChartType (+ groupBy / by variants).
+ */
+
+export type PanelMeta = {
+  id: string;
+  type: string;
+  title: string;
+  hint: string;
+  defaultW: number;
+  defaultH: number;
+  groupBy?: string;
+  by?: string;
+};
+
+export type ChartItem = {
+  type: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  groupBy?: string;
+  by?: string;
+};
+
+/** @type {ReadonlyArray<PanelMeta>} */
+export const PANEL_CATALOG: ReadonlyArray<PanelMeta> = Object.freeze([
+  { id: "pie", type: "pie", title: "Current status", hint: "2×2", defaultW: 2, defaultH: 2 },
+  {
+    id: "testingPyramid",
+    type: "testingPyramid",
+    title: "Testing pyramid",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "testResultSeverities",
+    type: "testResultSeverities",
+    title: "Results by severity",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "statusDynamics",
+    type: "statusDynamics",
+    title: "Status dynamics",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "statusTransitions",
+    type: "statusTransitions",
+    title: "Status transitions",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "testBaseGrowthDynamics",
+    type: "testBaseGrowthDynamics",
+    title: "Test base growth",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "coverageDiff",
+    type: "coverageDiff",
+    title: "Coverage diff",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "successRateDistribution",
+    type: "successRateDistribution",
+    title: "Success rate",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "problemsDistribution",
+    type: "problemsDistribution",
+    by: "environment",
+    title: "Problems by environment",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "stabilityByComponent",
+    type: "stabilityDistribution",
+    groupBy: "label-name:component",
+    title: "Stability by component",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "stabilityByFeature",
+    type: "stabilityDistribution",
+    groupBy: "feature",
+    title: "Stability by feature",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "stabilityByEpic",
+    type: "stabilityDistribution",
+    groupBy: "epic",
+    title: "Stability by epic",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "stabilityByStory",
+    type: "stabilityDistribution",
+    groupBy: "story",
+    title: "Stability by story",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "durations",
+    type: "durations",
+    title: "Durations",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "durationsByLayer",
+    type: "durations",
+    groupBy: "layer",
+    title: "Durations by layer",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "durationDynamics",
+    type: "durationDynamics",
+    title: "Duration dynamics",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+  {
+    id: "statusAgePyramid",
+    type: "statusAgePyramid",
+    title: "Status age pyramid",
+    hint: "2×2",
+    defaultW: 2,
+    defaultH: 2,
+  },
+]);
+
+export const PANEL_META: Readonly<Record<string, PanelMeta>> = Object.freeze(
+  Object.fromEntries(PANEL_CATALOG.map((p) => [p.id, p])),
+);
+
+/** Chart types known to the catalog (unique `type` values). */
+export const CHART_TYPES: ReadonlySet<string> = Object.freeze(
+  new Set(PANEL_CATALOG.map((p) => p.type)),
+);
+
+/**
+ * Resolve palette meta by id, or by type + groupBy/by (pie ↔ currentStatus).
+ */
+export function resolvePanelMeta(
+  raw: Partial<ChartItem> & { id?: string },
+): PanelMeta | undefined {
+  if (raw.id && PANEL_META[raw.id]) return PANEL_META[raw.id];
+  const type = raw.type || "";
+  const groupBy = raw.groupBy || undefined;
+  const by = raw.by || undefined;
+  const exact = PANEL_CATALOG.find(
+    (p) =>
+      p.type === type &&
+      (p.groupBy || undefined) === groupBy &&
+      (p.by || undefined) === by,
+  );
+  if (exact) return exact;
+  if (type === "currentStatus") return PANEL_META.pie;
+  return PANEL_CATALOG.find((p) => p.type === type && !p.groupBy && !p.by);
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,50 @@
+/**
+ * @allure-notifications/config — shared config schema + builder catalog / presets.
+ *
+ * Phase 1 SSOT for `config.json` (SQ-1080 free + chrome knobs).
+ * Extracted from allure-notifications-builder `js/app.js` (builder still has a local copy
+ * until Phase 4 wires imports after `apps/builder/` merge).
+ */
+
+export const PACKAGE = "@allure-notifications/config";
+export const PHASE = 1;
+
+export {
+  PANEL_CATALOG,
+  PANEL_META,
+  CHART_TYPES,
+  resolvePanelMeta,
+  type PanelMeta,
+  type ChartItem,
+} from "./catalog.js";
+
+export {
+  CANVAS_PRESETS,
+  DEFAULT_CANVAS,
+  GRID_COLS,
+  GRID_ROWS,
+  DEFAULT_HEADER_HEIGHT,
+  DEFAULT_CARD_GAP,
+  DEFAULT_TILE_PAD,
+  DEFAULT_ITEMS,
+  createDefaultConfig,
+  createSq1080Config,
+  type CanvasSize,
+  type DefaultConfigOptions,
+} from "./presets.js";
+
+export {
+  ChartItemSchema,
+  PanelsSchema,
+  ChartConfigSchema,
+  BaseSchema,
+  TelegramSchema,
+  ConfigSchema,
+  parseConfig,
+  safeParseConfig,
+  isValidConfig,
+  type ChartItemInput,
+  type ChartConfigInput,
+  type ConfigInput,
+  type Config,
+} from "./schema.js";

--- a/packages/config/src/presets.ts
+++ b/packages/config/src/presets.ts
@@ -1,0 +1,111 @@
+/**
+ * Canvas presets + SQ-1080 DEFAULT_ITEMS + chrome knobs.
+ * Extracted from allure-notifications-builder `js/app.js` / CANON.md.
+ */
+
+import type { ChartItem } from "./catalog.js";
+
+export type CanvasSize = { w: number; h: number };
+
+/** Presets only — 870×1080 · 1080×1080 · 1410×1080 (no 1024×1280). */
+export const CANVAS_PRESETS: Readonly<Record<string, CanvasSize>> = Object.freeze({
+  "870x1080": { w: 870, h: 1080 },
+  "1080x1080": { w: 1080, h: 1080 },
+  "1410x1080": { w: 1410, h: 1080 },
+});
+
+export const DEFAULT_CANVAS = "1080x1080" as const;
+
+export const GRID_COLS = 10;
+export const GRID_ROWS = 10;
+
+/** Jar / SQ-1080 chrome defaults (CollageRenderer + widget-tile canon in builder). */
+export const DEFAULT_HEADER_HEIGHT = 22;
+export const DEFAULT_CARD_GAP = 14;
+/** Preview-only — maps to `--wt-pad`; jar parses but does not apply yet. */
+export const DEFAULT_TILE_PAD = 6;
+
+/**
+ * SQ-1080 canon — 7 tiles, 3 rows (3+3+4 cols).
+ * See builder CANON.md / `DEFAULT_ITEMS` in `js/app.js`.
+ */
+export const DEFAULT_ITEMS: ReadonlyArray<ChartItem> = Object.freeze([
+  { type: "testingPyramid", x: 0, y: 0, w: 3, h: 3 },
+  { type: "pie", x: 3, y: 0, w: 3, h: 3 },
+  { type: "durations", x: 6, y: 0, w: 4, h: 3 },
+  { type: "coverageDiff", x: 0, y: 3, w: 3, h: 3 },
+  { type: "successRateDistribution", x: 3, y: 3, w: 3, h: 3 },
+  { type: "problemsDistribution", x: 6, y: 3, w: 4, h: 3, by: "environment" },
+  { type: "stabilityDistribution", x: 6, y: 6, w: 4, h: 4, groupBy: "feature" },
+]);
+
+export type DefaultConfigOptions = {
+  project?: string;
+  environment?: string;
+  comment?: string;
+  language?: string;
+  allureFolder?: string;
+  allureResultsFolder?: string;
+  canvas?: keyof typeof CANVAS_PRESETS;
+  telegram?: {
+    token?: string;
+    chat?: string;
+    topic?: string;
+    replyTo?: string;
+    templatePath?: string;
+  };
+};
+
+/**
+ * Builder-shaped default `config.json` (SQ-1080 free + chrome knobs).
+ * Matches `createDefaultState()` export from the builder (minus UI-only `vector`).
+ */
+export function createDefaultConfig(opts: DefaultConfigOptions = {}) {
+  const canvasKey = opts.canvas ?? DEFAULT_CANVAS;
+  const canvas = CANVAS_PRESETS[canvasKey];
+  if (!canvas) {
+    throw new Error(`Unknown canvas preset: ${String(canvasKey)}`);
+  }
+
+  return {
+    base: {
+      project: opts.project ?? "",
+      environment: opts.environment ?? "",
+      comment: opts.comment ?? "",
+      language: opts.language ?? "en",
+      allureFolder: opts.allureFolder ?? "allure-report/",
+      allureResultsFolder: opts.allureResultsFolder ?? "allure-results/",
+      enableChart: true,
+      darkMode: true,
+      chart: {
+        mode: "collage" as const,
+        layout: "free" as const,
+        width: canvas.w,
+        height: canvas.h,
+        headerHeight: DEFAULT_HEADER_HEIGHT,
+        cardGap: DEFAULT_CARD_GAP,
+        tilePad: DEFAULT_TILE_PAD,
+        gridCols: GRID_COLS,
+        gridRows: GRID_ROWS,
+        items: DEFAULT_ITEMS.map((p) => ({ ...p })),
+        pyramidFallback: "suites",
+      },
+      links: {
+        report: "",
+        dashboard: "",
+        testops: "",
+        build: "",
+      },
+    },
+    telegram: {
+      token: opts.telegram?.token ?? "",
+      chat: opts.telegram?.chat ?? "",
+      topic: opts.telegram?.topic ?? "",
+      replyTo: opts.telegram?.replyTo ?? "",
+      templatePath: opts.telegram?.templatePath ?? "/templates/telegram.ftl",
+    },
+  };
+}
+
+/** Alias — SQ-1080 is the default canvas. */
+export const createSq1080Config = createDefaultConfig;

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -1,0 +1,143 @@
+/**
+ * Zod schema for allure-notifications `config.json`.
+ * Shape matches jar Config (base + messengers) with 5.0+ chart free-grid + chrome knobs.
+ */
+
+import { z } from "zod";
+
+const LanguageSchema = z.enum(["en", "fr", "ru", "ua", "cn", "cnt", "by"]);
+
+const LinksSchema = z
+  .object({
+    report: z.string().optional(),
+    dashboard: z.string().optional(),
+    testops: z.string().optional(),
+    build: z.string().optional(),
+  })
+  .passthrough();
+
+/** Free-grid cell — `{ type, x, y, w, h }` + optional catalog variants. */
+export const ChartItemSchema = z
+  .object({
+    type: z.string().min(1),
+    x: z.number().int().nonnegative(),
+    y: z.number().int().nonnegative(),
+    w: z.number().int().positive(),
+    h: z.number().int().positive(),
+    by: z.string().min(1).optional(),
+    groupBy: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+/**
+ * `panels`: flat `string[]` (single row) or `string[][]` (rows) — jar PanelsDeserializer.
+ */
+export const PanelsSchema = z.union([
+  z.array(z.string().min(1)),
+  z.array(z.array(z.string().min(1))),
+]);
+
+export const ChartConfigSchema = z
+  .object({
+    mode: z.enum(["pie", "collage"]).optional(),
+    layout: z.enum(["grid", "stacked", "row", "free"]).optional(),
+    panels: PanelsSchema.optional(),
+    items: z.array(ChartItemSchema).optional(),
+    gridCols: z.number().int().positive().optional(),
+    gridRows: z.number().int().positive().optional(),
+    width: z.number().int().positive().optional(),
+    height: z.number().int().positive().optional(),
+    /** Card title-bar height (px). Builder SQ-1080 default 22; jar unset → renderer 68. */
+    headerHeight: z.number().int().positive().optional().nullable(),
+    /** Gap around/between cards (px). Default 14. */
+    cardGap: z.number().int().nonnegative().optional().nullable(),
+    /** Inner body pad (px) — preview/builder parity; jar parses, may ignore. */
+    tilePad: z.number().int().nonnegative().optional().nullable(),
+    pyramidFallback: z.string().optional(),
+    historyPath: z.string().optional().nullable(),
+    historyLimit: z.number().int().positive().optional().nullable(),
+  })
+  .passthrough()
+  .superRefine((chart, ctx) => {
+    if (chart.layout === "free") {
+      if (!chart.items || chart.items.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'chart.layout "free" requires a non-empty chart.items array',
+          path: ["items"],
+        });
+      }
+    }
+  });
+
+export const BaseSchema = z
+  .object({
+    project: z.string().optional(),
+    environment: z.string().optional(),
+    comment: z.string().optional(),
+    /** @deprecated use links.report */
+    reportLink: z.string().optional(),
+    links: LinksSchema.optional(),
+    language: LanguageSchema.optional(),
+    logo: z.string().optional(),
+    allureFolder: z.string().optional(),
+    allureResultsFolder: z.string().optional(),
+    enableChart: z.boolean().optional(),
+    chart: ChartConfigSchema.optional(),
+    darkMode: z.boolean().optional(),
+    enableSuitesPublishing: z.boolean().optional(),
+    durationFormat: z.string().optional(),
+    customData: z.record(z.string()).optional(),
+  })
+  .passthrough();
+
+export const TelegramSchema = z
+  .object({
+    token: z.string().optional(),
+    chat: z.string().optional(),
+    topic: z.string().optional(),
+    replyTo: z.string().optional(),
+    templatePath: z.string().optional(),
+  })
+  .passthrough();
+
+/** Loose messenger blocks — validated structurally in later phases. */
+const LooseMessengerSchema = z.record(z.unknown()).optional();
+
+/**
+ * Root `config.json` schema.
+ * Requires `base`. Telegram is the primary 6.0 messenger; others pass through.
+ */
+export const ConfigSchema = z
+  .object({
+    base: BaseSchema,
+    telegram: TelegramSchema.optional(),
+    slack: LooseMessengerSchema,
+    mattermost: LooseMessengerSchema,
+    mail: LooseMessengerSchema,
+    discord: LooseMessengerSchema,
+    loop: LooseMessengerSchema,
+    rocketChat: LooseMessengerSchema,
+    cliq: LooseMessengerSchema,
+    teams: LooseMessengerSchema,
+    proxy: LooseMessengerSchema,
+  })
+  .passthrough();
+
+export type ChartItemInput = z.infer<typeof ChartItemSchema>;
+export type ChartConfigInput = z.infer<typeof ChartConfigSchema>;
+export type ConfigInput = z.infer<typeof ConfigSchema>;
+export type Config = ConfigInput;
+
+export function parseConfig(data: unknown): Config {
+  return ConfigSchema.parse(data);
+}
+
+export function safeParseConfig(data: unknown) {
+  return ConfigSchema.safeParse(data);
+}
+
+/** True when `data` is a valid config.json. */
+export function isValidConfig(data: unknown): data is Config {
+  return ConfigSchema.safeParse(data).success;
+}

--- a/packages/config/test/schema.test.ts
+++ b/packages/config/test/schema.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+import {
+  CANVAS_PRESETS,
+  DEFAULT_CARD_GAP,
+  DEFAULT_HEADER_HEIGHT,
+  DEFAULT_ITEMS,
+  DEFAULT_TILE_PAD,
+  PANEL_CATALOG,
+  createDefaultConfig,
+  createSq1080Config,
+  parseConfig,
+  resolvePanelMeta,
+  safeParseConfig,
+} from "../src/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+/** Compiled at packages/config/dist/test → monorepo root is ../../../.. */
+const REPO_ROOT = join(__dirname, "../../../..");
+const CONFIG_DIR = join(REPO_ROOT, "config");
+
+function loadJson(name: string): unknown {
+  return JSON.parse(readFileSync(join(CONFIG_DIR, name), "utf8"));
+}
+
+describe("@allure-notifications/config catalog", () => {
+  it("exposes 17 panel catalog slots", () => {
+    assert.equal(PANEL_CATALOG.length, 17);
+    const ids = new Set(PANEL_CATALOG.map((p) => p.id));
+    assert.equal(ids.size, 17);
+  });
+
+  it("resolves pie ↔ currentStatus and groupBy variants", () => {
+    assert.equal(resolvePanelMeta({ type: "currentStatus" })?.id, "pie");
+    assert.equal(
+      resolvePanelMeta({
+        type: "stabilityDistribution",
+        groupBy: "feature",
+      })?.id,
+      "stabilityByFeature",
+    );
+    assert.equal(
+      resolvePanelMeta({ type: "problemsDistribution", by: "environment" })?.id,
+      "problemsDistribution",
+    );
+  });
+});
+
+describe("@allure-notifications/config presets", () => {
+  it("has three canvas presets and SQ-1080 DEFAULT_ITEMS (7 tiles)", () => {
+    assert.deepEqual(Object.keys(CANVAS_PRESETS).sort(), [
+      "1080x1080",
+      "1410x1080",
+      "870x1080",
+    ]);
+    assert.equal(DEFAULT_ITEMS.length, 7);
+    assert.equal(DEFAULT_HEADER_HEIGHT, 22);
+    assert.equal(DEFAULT_CARD_GAP, 14);
+    assert.equal(DEFAULT_TILE_PAD, 6);
+  });
+
+  it("createDefaultConfig / createSq1080Config export validates", () => {
+    const cfg = createSq1080Config({
+      project: "phase1-test",
+      telegram: { token: "0:t", chat: "1" },
+    });
+    const parsed = parseConfig(cfg);
+    assert.equal(parsed.base.chart?.layout, "free");
+    assert.equal(parsed.base.chart?.width, 1080);
+    assert.equal(parsed.base.chart?.height, 1080);
+    assert.equal(parsed.base.chart?.headerHeight, 22);
+    assert.equal(parsed.base.chart?.cardGap, 14);
+    assert.equal(parsed.base.chart?.tilePad, 6);
+    assert.equal(parsed.base.chart?.items?.length, 7);
+    assert.equal(parsed.telegram?.token, "0:t");
+  });
+
+  it("createDefaultConfig(870x1080) validates", () => {
+    const cfg = createDefaultConfig({ canvas: "870x1080" });
+    const parsed = parseConfig(cfg);
+    assert.equal(parsed.base.chart?.width, 870);
+    assert.equal(parsed.base.chart?.height, 1080);
+  });
+});
+
+describe("@allure-notifications/config schema vs repo fixtures", () => {
+  it("validates builder-shaped SQ-1080 default (synthetic export)", () => {
+    const exported = createDefaultConfig();
+    const result = safeParseConfig(exported);
+    assert.equal(result.success, true, result.success ? "" : JSON.stringify(result.error.format()));
+  });
+
+  it("validates config.preview-sq1080.json", () => {
+    const data = loadJson("config.preview-sq1080.json");
+    const result = safeParseConfig(data);
+    assert.equal(result.success, true, result.success ? "" : JSON.stringify(result.error.format()));
+  });
+
+  it("validates config.dogfood-builder-cb870.json", () => {
+    const data = loadJson("config.dogfood-builder-cb870.json");
+    const result = safeParseConfig(data);
+    assert.equal(result.success, true, result.success ? "" : JSON.stringify(result.error.format()));
+  });
+
+  it("validates config-5.0-collage.example.json (legacy panels flat array)", () => {
+    const data = loadJson("config-5.0-collage.example.json");
+    const result = safeParseConfig(data);
+    assert.equal(result.success, true, result.success ? "" : JSON.stringify(result.error.format()));
+  });
+
+  it("rejects free layout without items", () => {
+    const bad = {
+      base: {
+        chart: {
+          mode: "collage",
+          layout: "free",
+          width: 1080,
+          height: 1080,
+        },
+      },
+    };
+    const result = safeParseConfig(bad);
+    assert.equal(result.success, false);
+  });
+
+  it("rejects negative chart item coordinates", () => {
+    const bad = {
+      base: {
+        chart: {
+          mode: "collage",
+          layout: "free",
+          width: 1080,
+          height: 1080,
+          items: [{ type: "pie", x: -1, y: 0, w: 2, h: 2 }],
+        },
+      },
+    };
+    const result = safeParseConfig(bad);
+    assert.equal(result.success, false);
+  });
+});

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "rootDir": ".",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,50 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  packages/config:
+    dependencies:
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.20.1
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "packages/*"
+  - "apps/*"


### PR DESCRIPTION
## Summary

- **Phase 0:** TypeScript monorepo shell — root `package.json` **6.0.0**, `pnpm-workspace.yaml`, `MIGRATION.md`, `docs/phase-0-checklist.md`, `docs/ci-cookbook.md`.
- **Phase 1:** `@allure-notifications/config` — zod schema, `PANEL_CATALOG` (17), `DEFAULT_ITEMS` / SQ-1080 presets, unit tests (11 pass) + `pnpm-lock.yaml`.
- **5.0.* Java freeze stays on `master`** (jar modules untouched). **No 5.1 line** — next product line is **6.0.***.
- Layout moves (`legacy/java/`, `apps/builder` merge, stand cwd) remain **deferred** (checklist only).
- Monorepo pin `docs/allure-notifications/VERSION` stays **5.0.8** until dogfood cutover (out of this repo).

## Locked / out of scope

- Not A3 plugin, not Jenkins plugin, no `dashboard-overrides`/HTML inject in npm.
- No Phase 2 (`packages/pyramid`), Phase 3 CLI, native PNG, or Playwright production PNG.

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter @allure-notifications/config test` — 11/11 pass
- [ ] CI on this PR (if any TS job exists; Java tree unchanged)

## Next

**Phase 2 — `packages/pyramid`** (palette + rounded-tier geometry SSOT) after merge / explicit OK.


Made with [Cursor](https://cursor.com)