### PR TITLE
feat(quality): Q2 Sonar soft scan (allure-notifications)

### DIFF
--- a/.github/workflows/ci-6.0.yml
+++ b/.github/workflows/ci-6.0.yml
@@ -1,6 +1,7 @@
 # 6.0 TypeScript monorepo CI (master + feature/6.0* + quality contour lines).
 # Java 5.0.8 jar CI stays in build.yml (master) — do not merge jobs.
 # Q1: Allure results + generate + soft c8 coverage artifacts (no % gate).
+# Q2: Sonar upload + sonar-gate-wait (soft SONAR_REQUIRED=false).
 
 name: CI 6.0 (TypeScript)
 
@@ -22,6 +23,7 @@ on:
       - 'apps/**'
       - 'scripts/**'
       - 'c8.config.json'
+      - 'sonar-project.properties'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -113,3 +115,57 @@ jobs:
           path: coverage/
           if-no-files-found: warn
           retention-days: 7
+
+  sonar:
+    name: Sonar (soft)
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # Forks: job still runs for visibility, but never receives SONAR_TOKEN (soft-skip in script).
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+
+      - name: Sonar scan + gate (soft)
+        env:
+          # Never pass token on fork PRs (secrets are empty there anyway; explicit for clarity).
+          SONAR_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SONAR_TOKEN || '' }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonar.qa.guru' }}
+          SONAR_REQUIRED: ${{ vars.SONAR_REQUIRED || 'false' }}
+          SONAR_PROJECT_KEY: allure-notifications
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: bash scripts/ci-sonar.sh
+
+      - name: Job summary
+        if: always()
+        env:
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonar.qa.guru' }}
+        run: |
+          {
+            echo "## Sonar (soft)"
+            echo ""
+            echo "- projectKey: \`allure-notifications\`"
+            echo "- host: \`${SONAR_HOST_URL}\`"
+            echo "- dashboard: ${SONAR_HOST_URL%/}/dashboard?id=allure-notifications"
+            echo "- SONAR_REQUIRED: \`${{ vars.SONAR_REQUIRED || 'false' }}\`"
+            echo "- commit: \`${GITHUB_SHA:0:7}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -38,7 +38,7 @@ Fixture config already points at `packages/core/test/fixtures/dogfood-report` + 
 
 ## GitHub Actions — product CI (this repo)
 
-TS tests live in [`.github/workflows/ci-6.0.yml`](../.github/workflows/ci-6.0.yml) (`pnpm i` + `pnpm typecheck` + `pnpm test` + soft `pnpm coverage` + `pnpm allure:generate` on `master` + `feature/6.0*` + `feature/quality-*`). Artifacts: `allure-results/` · `allure-report/` · `coverage/` (retain ≥7d). Builder Pages: [`pages-builder.yml`](../.github/workflows/pages-builder.yml) (static `apps/builder/` on `master` + `feature/6.0*`; see [`pages-cutover.md`](pages-cutover.md)). Java jar CI stays in [`build.yml`](../.github/workflows/build.yml) (**master** only; cwd `legacy/java`).
+TS tests live in [`.github/workflows/ci-6.0.yml`](../.github/workflows/ci-6.0.yml) (`pnpm i` + `pnpm typecheck` + `pnpm test` + soft `pnpm coverage` + `pnpm allure:generate` on `master` + `feature/6.0*` + `feature/quality-*`). Artifacts: `allure-results/` · `allure-report/` · `coverage/` (retain ≥7d). Job **Sonar (soft)** needs coverage → `scripts/ci-sonar.sh` + vendored `scripts/sonar-gate-wait.py` (`projectKey=allure-notifications`; `SONAR_REQUIRED=false`). Builder Pages: [`pages-builder.yml`](../.github/workflows/pages-builder.yml) (static `apps/builder/` on `master` + `feature/6.0*`; see [`pages-cutover.md`](pages-cutover.md)). Java jar CI stays in [`build.yml`](../.github/workflows/build.yml) (**master** only; cwd `legacy/java`).
 
 ## Own tests → Allure results (Q1)
 
@@ -62,6 +62,26 @@ Notes:
 - `ALLURE_RESULTS_DIR` must point at the **repo root** `allure-results/` (root `scripts/run-tests.mjs`); do not write into package cwd.
 - Coverage excludes: `dist` test emit noise, `node_modules`, `vendor`, `test/fixtures`, `apps/builder/js`, `**/*.test.*`. Soft collect only until Q5.
 - Forks/PR: no live secrets needed for this path (tests + Allure generate + coverage artifact).
+
+## Sonar (Q2, soft)
+
+One Sonar project for the TS monorepo: **`allure-notifications`** → [dashboard](https://sonar.qa.guru/dashboard?id=allure-notifications).  
+Config: [`sonar-project.properties`](../sonar-project.properties). Coverage in: `coverage/lcov.info` (from `pnpm coverage`).  
+Gate poll: vendored thin copy [`scripts/sonar-gate-wait.py`](../scripts/sonar-gate-wait.py) (nested CI has no monorepo `scripts/`; keep in sync with zds `scripts/sonar-gate-wait.py`). Wrapper: [`scripts/ci-sonar.sh`](../scripts/ci-sonar.sh).
+
+| Var / secret | Kind | Default / note |
+|--------------|------|----------------|
+| `SONAR_TOKEN` | secret | never on fork PRs |
+| `SONAR_HOST_URL` | var | `https://sonar.qa.guru` |
+| `SONAR_REQUIRED` | var | `false` until Q5 — soft-skip on missing token / host down / gate ≠ PASSED |
+
+Local dry-run (no token, no upload):
+
+```bash
+python scripts/sonar-gate-wait.py --project-key allure-notifications --dry-run
+# optional: after pnpm coverage, full soft path (skips without SONAR_TOKEN)
+SONAR_REQUIRED=false bash scripts/ci-sonar.sh
+```
 
 ## GitHub Actions — consumer notify (dry-run)
 

--- a/scripts/ci-sonar.sh
+++ b/scripts/ci-sonar.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Soft Sonar upload + quality gate poll for allure-notifications (Q2).
+# Soft-skip when: fork / no SONAR_TOKEN / host down / gate ≠ PASSED (unless SONAR_REQUIRED=true).
+# Env: SONAR_TOKEN, SONAR_HOST_URL (default https://sonar.qa.guru), SONAR_REQUIRED (default false)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+export SONAR_HOST_URL="${SONAR_HOST_URL:-https://sonar.qa.guru}"
+export SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-allure-notifications}"
+export SONAR_REQUIRED="${SONAR_REQUIRED:-false}"
+
+soft_skip() {
+  local msg="$1"
+  if [[ "$SONAR_REQUIRED" == "true" ]]; then
+    echo "ERROR: $msg (SONAR_REQUIRED=true)" >&2
+    exit 1
+  fi
+  echo "WARNING: $msg — soft-skip (SONAR_REQUIRED=false)"
+  exit 0
+}
+
+if [[ "${IS_FORK:-}" == "true" ]]; then
+  soft_skip "fork PR — never pass SONAR_TOKEN / skip scan"
+fi
+
+if [[ -z "${SONAR_TOKEN:-}" ]]; then
+  soft_skip "SONAR_TOKEN unset — skip sonar upload"
+fi
+
+if ! curl -sf --max-time 15 "${SONAR_HOST_URL%/}/api/system/status" >/dev/null; then
+  soft_skip "Sonar host unreachable: ${SONAR_HOST_URL}"
+fi
+
+if [[ ! -f coverage/lcov.info ]]; then
+  soft_skip "coverage/lcov.info missing — run pnpm coverage / download artifact first"
+fi
+
+echo "==> sonar-scanner → ${SONAR_HOST_URL} (${SONAR_PROJECT_KEY})"
+# Token via env only (never argv / logs). @sonar/scan reads SONAR_TOKEN + SONAR_HOST_URL.
+npx --yes @sonar/scan \
+  -Dsonar.projectKey="${SONAR_PROJECT_KEY}" \
+  -Dsonar.projectName="${SONAR_PROJECT_KEY}"
+echo "==> quality gate poll"
+if command -v python >/dev/null 2>&1; then
+  PY=python
+elif command -v python3 >/dev/null 2>&1; then
+  PY=python3
+else
+  soft_skip "no python for gate poll"
+fi
+
+set +e
+"$PY" scripts/sonar-gate-wait.py \
+  --url "${SONAR_HOST_URL}" \
+  --project-key "${SONAR_PROJECT_KEY}"
+gate_ec=$?
+set -e
+
+if [[ $gate_ec -eq 0 ]]; then
+  echo "OK: quality gate PASSED"
+  exit 0
+fi
+
+soft_skip "quality gate not PASSED (exit=${gate_ec})"

--- a/scripts/sonar-gate-wait.py
+++ b/scripts/sonar-gate-wait.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""Vendored thin copy of monorepo scripts/sonar-gate-wait.py (self-contained).
+
+Nested CI has no monorepo scripts/ — keep this file in sync when the gate poll
+contract changes. Canon: docs/sonar/SONAR-CANON.md · QUALITY-CONTOUR §4.
+
+Smoke: python scripts/sonar-gate-wait.py --project-key allure-notifications --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def emit(result: dict, *, exit_code: int | None = None) -> None:
+    print(json.dumps(result, ensure_ascii=False))
+    if exit_code is not None:
+        sys.exit(exit_code)
+    sys.exit(0 if result.get("ok", False) else 1)
+
+
+def usage_error(message: str) -> None:
+    print(message, file=sys.stderr)
+    emit({"ok": False, "error": message}, exit_code=2)
+
+
+def fetch_gate_status(base_url: str, project_key: str, token: str) -> dict:
+    qs = urllib.parse.urlencode({"projectKey": project_key})
+    url = f"{base_url.rstrip('/')}/api/qualitygates/project_status?{qs}"
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    project_status = payload.get("projectStatus", {})
+    status = project_status.get("status", "UNKNOWN")
+    conditions = project_status.get("conditions", [])
+    return {
+        "status": status,
+        "conditions": conditions,
+        "dashboard_url": f"{base_url.rstrip('/')}/dashboard?id={urllib.parse.quote(project_key)}",
+    }
+
+
+def run(url: str, project_key: str, timeout: int, poll: int, dry_run: bool) -> dict:
+    if dry_run:
+        return {
+            "ok": True,
+            "dry_run": True,
+            "status": "PASSED",
+            "project_key": project_key,
+            "url": url,
+            "conditions": [],
+            "dashboard_url": f"{url.rstrip('/')}/dashboard?id={project_key}",
+        }
+
+    token = os.environ.get("SONAR_TOKEN", "")
+    if not token:
+        return {
+            "ok": False,
+            "error": "SONAR_TOKEN not set (use --dry-run for local smoke)",
+            "project_key": project_key,
+        }
+
+    deadline = time.monotonic() + timeout
+    last: dict | None = None
+    while time.monotonic() < deadline:
+        try:
+            last = fetch_gate_status(url, project_key, token)
+        except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as exc:
+            last = {"status": "ERROR", "error": str(exc)}
+        else:
+            if last["status"] in ("OK", "PASSED", "FAILED", "ERROR"):
+                break
+        time.sleep(poll)
+
+    if last is None:
+        return {"ok": False, "error": "no response from Sonar", "project_key": project_key}
+
+    status = last.get("status", "UNKNOWN")
+    passed = status in ("OK", "PASSED")
+    return {
+        "ok": passed,
+        "status": status,
+        "project_key": project_key,
+        "conditions": last.get("conditions", []),
+        "dashboard_url": last.get("dashboard_url"),
+        "timed_out": status not in ("OK", "PASSED", "FAILED", "ERROR"),
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Poll sonar.qa.guru quality gate until PASSED/FAILED.")
+    parser.add_argument("--url", default="https://sonar.qa.guru")
+    parser.add_argument("--project-key", required=True)
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--poll", type=int, default=15)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.project_key.strip():
+        usage_error("--project-key is required")
+
+    result = run(args.url, args.project_key, args.timeout, args.poll, args.dry_run)
+    emit(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+# SonarQube — allure-notifications (TS monorepo, one projectKey).
+# Canon: docs/allure-notifications/QUALITY-CONTOUR.md §4 · docs/sonar/SONAR-CANON.md
+sonar.projectKey=allure-notifications
+sonar.projectName=allure-notifications
+sonar.sources=packages/config/src,packages/pyramid/src,packages/core/src,packages/cli/src,apps/builder/src
+sonar.tests=packages/config/test,packages/pyramid/test,packages/core/test,packages/cli/test,apps/builder/tests
+sonar.sourceEncoding=UTF-8
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.coverage.exclusions=**/test/**,**/*.test.*,**/vendor/**,**/dist/**,apps/builder/js/**
+sonar.exclusions=**/node_modules/**,**/vendor/**,**/dist/**,**/coverage/**,**/allure-results/**,**/allure-report/**


### PR DESCRIPTION
## Summary
- Sonar projectKey **`allure-notifications`** (sources: `packages/*/src`, `apps/builder/src`; coverage: `coverage/lcov.info`)
- Vendored thin `scripts/sonar-gate-wait.py` + `scripts/ci-sonar.sh` + `sonar-project.properties`
- CI job `sonar` in `ci-6.0.yml` (needs test/coverage): soft `SONAR_REQUIRED=false`; forks never get `SONAR_TOKEN`
- Cookbook: local dry-run for gate poll

## Test plan
- [ ] CI on this PR: `pnpm test` still blocker; Sonar soft-skip or scan upload when `SONAR_TOKEN` present
- [ ] Dashboard: https://sonar.qa.guru/dashboard?id=allure-notifications shows analysis after token run
- [ ] Fork / no token: soft-skip warning, job green
- [ ] VERSION stays **6.0.4** (no bump)


Made with [Cursor](https://cursor.com)