### PR TITLE
feat(quality): Q4 Telegram dry-run / live

### DIFF
--- a/.github/workflows/ci-6.0.yml
+++ b/.github/workflows/ci-6.0.yml
@@ -3,6 +3,7 @@
 # Q1: Allure results + generate + soft c8 coverage artifacts (no % gate).
 # Q2: Sonar upload + sonar-gate-wait (soft SONAR_REQUIRED=false).
 # Q3: TestOps upload+close via allurectl (informational; skip without ALLURE_*).
+# Q4: Telegram collage dry-run (PR) / live (master + workflow_dispatch; never forks).
 
 name: CI 6.0 (TypeScript)
 
@@ -23,6 +24,7 @@ on:
       - 'packages/**'
       - 'apps/**'
       - 'scripts/**'
+      - 'config/ci-telegram.json'
       - 'c8.config.json'
       - 'sonar-project.properties'
       - 'package.json'
@@ -293,4 +295,131 @@ jobs:
             fi
             echo "- commit: \`${GITHUB_SHA:0:7}\`"
             echo "- launch name: \`allure-notifications · ${{ github.ref_name }} · ${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  telegram:
+    name: Telegram (dry-run / live)
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # PR / feature push: --dry-run (wiring must pass).
+    # master + workflow_dispatch: --live when TELEGRAM_* present; else soft-skip.
+    # Forks: never --live.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download allure-report
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-report
+          path: allure-report/
+
+      - name: Download allure-results
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-results
+          path: allure-results/
+
+      - name: Gate (mode)
+        id: gate
+        env:
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          # Never pass token on fork PRs.
+          TELEGRAM_BOT_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (secrets.TELEGRAM_BOT_TOKEN || secrets.TELEGRAM_TOKEN) || '' }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          # Default: dry-run (PR + feature branches). Live only master push or workflow_dispatch.
+          MODE=dry-run
+          REASON=dry-run
+          if [[ "$IS_FORK" == "true" ]]; then
+            MODE=dry-run
+            REASON=fork-dry-run
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" || ( "$EVENT_NAME" == "push" && "$REF_NAME" == "master" ) ]]; then
+            if [[ -n "${TELEGRAM_BOT_TOKEN}" && -n "${TELEGRAM_CHAT_ID}" ]]; then
+              MODE=live
+              REASON=live
+            else
+              MODE=skip
+              REASON=missing-secrets
+            fi
+          fi
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+          echo "reason=${REASON}" >> "$GITHUB_OUTPUT"
+          echo "Gate: mode=${MODE} reason=${REASON}"
+
+      - name: Send Telegram collage
+        id: send
+        if: steps.gate.outputs.mode != 'skip'
+        env:
+          MODE: ${{ steps.gate.outputs.mode }}
+          CLI_PIN: '6.0.4'
+          REF_NAME: ${{ github.ref_name }}
+          SHORT_SHA: ${{ github.sha }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TELEGRAM_BOT_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (secrets.TELEGRAM_BOT_TOKEN || secrets.TELEGRAM_TOKEN) || '' }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID || '-1004381150566' }}
+          TELEGRAM_TOPIC_ID: ${{ vars.TELEGRAM_TOPIC_ID || vars.TELEGRAM_ALLURE_NOTIFICATIONS_TOPIC_ID || '34' }}
+        run: bash scripts/ci-telegram.sh
+
+      - name: Upload collage artifact
+        if: ${{ !cancelled() && steps.send.outputs.collage != '' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: collage-telegram
+          path: collage-telegram.png
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Job summary
+        if: always()
+        env:
+          GATE_MODE: ${{ steps.gate.outputs.mode }}
+          GATE_REASON: ${{ steps.gate.outputs.reason }}
+          SEND_MODE: ${{ steps.send.outputs.mode }}
+          SEND_SOURCE: ${{ steps.send.outputs.source }}
+          MESSAGE_ID: ${{ steps.send.outputs.message_id }}
+          SEND_EXIT: ${{ steps.send.outputs.send_exit }}
+        run: |
+          {
+            echo "## Telegram (Q4)"
+            echo ""
+            echo "- topic: slug \`allure-notifications\` → id **34** (ADR 008)"
+            echo "- CLI pin: \`allure-notifications@6.0.4\`"
+            echo "- gate: \`${GATE_MODE}\` (\`${GATE_REASON}\`)"
+            if [[ "${GATE_MODE}" == "skip" ]]; then
+              echo "- status: soft-skip (missing TELEGRAM_* — not a merge blocker)"
+            else
+              echo "- send mode: \`${SEND_MODE:-${GATE_MODE}}\`"
+              echo "- config source: \`${SEND_SOURCE:-n/a}\`"
+              if [[ -n "${MESSAGE_ID}" ]]; then
+                echo "- status: live sendPhoto ok"
+                echo "- message_id: \`${MESSAGE_ID}\`"
+              elif [[ "${GATE_MODE}" == "dry-run" || "${SEND_MODE}" == "dry-run" ]]; then
+                if [[ "${SEND_EXIT}" == "0" ]]; then
+                  echo "- status: dry-run ok (no network)"
+                else
+                  echo "- status: dry-run failed (wiring — fix required)"
+                fi
+              else
+                echo "- status: live attempted (see job log; soft on API blip)"
+              fi
+            fi
+            echo "- commit: \`${GITHUB_SHA:0:7}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/config/ci-telegram.json
+++ b/config/ci-telegram.json
@@ -2,10 +2,10 @@
   "base": {
     "project": "allure-notifications",
     "environment": "CI",
-    "comment": "cb870-mid-dynamics · library unit tests (dogfood)",
+    "comment": "Q4 quality contour · this-run Allure (fallback dogfood CB-870 in ci-telegram.sh)",
     "language": "en",
-    "allureFolder": "legacy/java/allure-notifications-api/build/allure-report/",
-    "allureResultsFolder": "legacy/java/allure-notifications-api/build/allure-results/",
+    "allureFolder": "../allure-report",
+    "allureResultsFolder": "../allure-results",
     "enableChart": true,
     "darkMode": true,
     "enableSuitesPublishing": false,

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -21,7 +21,7 @@ npx allure-notifications send --config config.json --dry-run
 | `--mock` | Render PNG; mock deliveries; **no network** |
 | `--out <png>` | Write PNG buffer to disk |
 
-Default without `--mock` / `--live` is safe **dry-run**. Live Telegram = explicit `--live` + env credentials ([`telegram-dogfood.md`](telegram-dogfood.md)); **not** in `ci-6.0.yml`.
+Default without `--mock` / `--live` is safe **dry-run**. Live Telegram = explicit `--live` + env credentials ([`telegram-dogfood.md`](telegram-dogfood.md)). Product CI job **`telegram`** in `ci-6.0.yml` (Q4): PR `--dry-run`; `master` / `workflow_dispatch` `--live` when secrets present.
 
 ## Workspace (local / before `npx`)
 
@@ -38,7 +38,7 @@ Fixture config already points at `packages/core/test/fixtures/dogfood-report` + 
 
 ## GitHub Actions — product CI (this repo)
 
-TS tests live in [`.github/workflows/ci-6.0.yml`](../.github/workflows/ci-6.0.yml) (`pnpm i` + `pnpm typecheck` + `pnpm test` + soft `pnpm coverage` + `pnpm allure:generate` on `master` + `feature/6.0*` + `feature/quality-*`). Artifacts: `allure-results/` · `allure-report/` · `coverage/` (retain ≥7d). Job **Sonar (soft)** needs coverage → `scripts/ci-sonar.sh` + vendored `scripts/sonar-gate-wait.py` (`projectKey=allure-notifications`; `SONAR_REQUIRED=false`). Job **TestOps (informational)** needs `allure-results` → `setup-allurectl@v1` + `allurectl upload` + close (soft-skip without `ALLURE_*`; forks never upload). Builder Pages: [`pages-builder.yml`](../.github/workflows/pages-builder.yml) (static `apps/builder/` on `master` + `feature/6.0*`; see [`pages-cutover.md`](pages-cutover.md)). Java jar CI stays in [`build.yml`](../.github/workflows/build.yml) (**master** only; cwd `legacy/java`).
+TS tests live in [`.github/workflows/ci-6.0.yml`](../.github/workflows/ci-6.0.yml) (`pnpm i` + `pnpm typecheck` + `pnpm test` + soft `pnpm coverage` + `pnpm allure:generate` on `master` + `feature/6.0*` + `feature/quality-*`). Artifacts: `allure-results/` · `allure-report/` · `coverage/` (retain ≥7d). Job **Sonar (soft)** needs coverage → `scripts/ci-sonar.sh` + vendored `scripts/sonar-gate-wait.py` (`projectKey=allure-notifications`; `SONAR_REQUIRED=false`). Job **TestOps (informational)** needs `allure-results` → `setup-allurectl@v1` + `allurectl upload` + close (soft-skip without `ALLURE_*`; forks never upload). Job **Telegram (Q4)** needs `allure-report` → `scripts/ci-telegram.sh` + `config/ci-telegram.json` (`npx allure-notifications@6.0.4`; PR dry-run / master live → topic 34). Builder Pages: [`pages-builder.yml`](../.github/workflows/pages-builder.yml) (static `apps/builder/` on `master` + `feature/6.0*`; see [`pages-cutover.md`](pages-cutover.md)). Java jar CI stays in [`build.yml`](../.github/workflows/build.yml) (**master** only; cwd `legacy/java`).
 
 ## Own tests → Allure results (Q1)
 
@@ -94,6 +94,32 @@ Upload this repo’s own `allure-results/` to Allure TestOps after the test job.
 | `ALLURE_PROJECT_ID` | var | TestOps project id (GH var only — not in git) |
 
 Launch name: `allure-notifications · <ref_name> · <sha>`. Job summary prints the launch URL when upload succeeds. Missing secrets / empty results / forks → soft-skip (job still green).
+
+## Telegram (Q4)
+
+Dogfood collage of **this run’s** Allure report into ADR 008 Monitoring topic **34** (`allure-notifications`). Wrapper: [`scripts/ci-telegram.sh`](../scripts/ci-telegram.sh). Template config: [`config/ci-telegram.json`](../config/ci-telegram.json) (points at `../allure-report` + `../allure-results`; runtime file gitignored). If `allure-report/summary.json` is missing → fallback dogfood CB-870 fixtures under `packages/core/test/fixtures/`.
+
+| Event | Mode |
+|-------|------|
+| Same-repo PR / feature push | `--dry-run` (no network; **fail = fix wiring**) |
+| `master` push / `workflow_dispatch` | `--live` when `TELEGRAM_*` present; else soft-skip |
+| Fork PR | never `--live` (dry-run only) |
+
+| Var / secret | Kind | Default / note |
+|--------------|------|----------------|
+| `TELEGRAM_BOT_TOKEN` or `TELEGRAM_TOKEN` | secret | never on fork PRs; never commit |
+| `TELEGRAM_CHAT_ID` | secret | `-1004381150566` |
+| `TELEGRAM_TOPIC_ID` | var | **34** (alias `TELEGRAM_ALLURE_NOTIFICATIONS_TOPIC_ID`) |
+
+CLI pin: `npx allure-notifications@6.0.4`. Optional artifact: `collage-telegram.png`. Job summary prints `message_id` on live success. Missing secrets on live path → soft-skip (not a merge blocker).
+
+Local rehearsal:
+
+```bash
+# with this-run report already generated:
+MODE=dry-run bash scripts/ci-telegram.sh
+# force dogfood fallback: move/rename allure-report/summary.json first
+```
 
 ## GitHub Actions — consumer notify (dry-run)
 

--- a/docs/telegram-dogfood.md
+++ b/docs/telegram-dogfood.md
@@ -59,10 +59,15 @@ node packages/cli/dist/src/bin.js send \
 
 - Unit tests mock `fetch` — **no** live network in default `pnpm test`.
 - Optional real send in tests: `ALLURE_NOTIFICATIONS_LIVE_TEST=1` + token env (off in CI).
-- `.github/workflows/ci-6.0.yml` does **not** set live flags or Telegram secrets.
+- Quality contour **Q4**: job **`telegram`** in [`.github/workflows/ci-6.0.yml`](../.github/workflows/ci-6.0.yml) via [`scripts/ci-telegram.sh`](../scripts/ci-telegram.sh).
+  - PR / feature: `npx allure-notifications@6.0.4 send --config … --dry-run` (+ optional collage artifact).
+  - `master` + `workflow_dispatch`: `--live` when `TELEGRAM_*` present → topic **34**; else soft-skip.
+  - Forks: never `--live`.
+  - Config prefers this run’s `allure-report/` / `allure-results/`; fallback dogfood CB-870.
 
 ## See also
 
 - ADR 008 · monorepo `docs/adr/008-allure-notifications-monitoring.md`
-- CI cookbook dry-run: [`ci-cookbook.md`](ci-cookbook.md)
+- CI cookbook: [`ci-cookbook.md`](ci-cookbook.md) (§ Telegram Q4)
 - Hub plan: `projects/allure-notifications-home/PLAN-6.0.md`
+- Instance contour: monorepo `docs/allure-notifications/QUALITY-CONTOUR.md`

--- a/scripts/ci-telegram.sh
+++ b/scripts/ci-telegram.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Q4 Telegram collage: dry-run (PR) / live (master + workflow_dispatch).
+# Prefer this run's allure-report/results; fallback dogfood CB-870.
+# Env:
+#   MODE=dry-run|live|skip
+#   TELEGRAM_BOT_TOKEN | TELEGRAM_TOKEN, TELEGRAM_CHAT_ID, TELEGRAM_TOPIC_ID (live)
+#   BUILD_URL, REF_NAME, SHORT_SHA (optional links / project label)
+# Pin: npx allure-notifications@6.0.4 (docs/allure-notifications/VERSION).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+MODE="${MODE:-dry-run}"
+CLI_PIN="${CLI_PIN:-6.0.4}"
+OUT_PNG="${OUT_PNG:-collage-telegram.png}"
+RUNTIME_CONFIG="${RUNTIME_CONFIG:-config/ci-telegram.runtime.json}"
+
+if [[ "$MODE" == "skip" ]]; then
+  echo "soft-skip: MODE=skip"
+  echo "source=skip" >> "${GITHUB_OUTPUT:-/dev/null}"
+  echo "mode=skip" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+if [[ "$MODE" != "dry-run" && "$MODE" != "live" ]]; then
+  echo "ERROR: MODE must be dry-run|live|skip (got: $MODE)" >&2
+  exit 1
+fi
+
+TEMPLATE="config/ci-telegram.json"
+SOURCE="run-allure-report"
+if [[ -f allure-report/summary.json ]]; then
+  echo "==> using this run's allure-report (+ allure-results if present)"
+else
+  SOURCE="dogfood-cb870"
+  echo "==> allure-report/summary.json missing — fallback dogfood CB-870"
+fi
+
+REF_NAME="${REF_NAME:-local}"
+SHORT_SHA="${SHORT_SHA:-0000000}"
+SHORT_SHA="${SHORT_SHA:0:7}"
+BUILD_URL="${BUILD_URL:-}"
+
+python - "$TEMPLATE" "$RUNTIME_CONFIG" "$SOURCE" "$REF_NAME" "$SHORT_SHA" "$BUILD_URL" <<'PY'
+import json, sys
+from pathlib import Path
+
+template, out, source, ref, sha, build = sys.argv[1:7]
+cfg = json.loads(Path(template).read_text())
+cfg["base"]["project"] = f"allure-notifications · {ref} · {sha}"
+cfg["base"]["environment"] = "CI"
+cfg["base"]["comment"] = (
+    "Q4 quality contour · this-run Allure"
+    if source == "run-allure-report"
+    else "Q4 quality contour · dogfood CB-870 fallback"
+)
+if source == "dogfood-cb870":
+    # Paths relative to config/ (same as TEMPLATE dir).
+    cfg["base"]["allureFolder"] = "../packages/core/test/fixtures/dogfood-report"
+    cfg["base"]["allureResultsFolder"] = "../packages/core/test/fixtures/dogfood-results"
+else:
+    cfg["base"]["allureFolder"] = "../allure-report"
+    cfg["base"]["allureResultsFolder"] = "../allure-results"
+
+links = cfg["base"].setdefault("links", {})
+if build:
+    links["build"] = build
+
+# Credentials stay empty in file — CLI resolves TELEGRAM_* from env (never commit).
+tg = cfg.setdefault("telegram", {})
+tg["token"] = ""
+tg["chat"] = ""
+tg["topic"] = ""
+tg["replyTo"] = ""
+
+Path(out).write_text(json.dumps(cfg, indent=2) + "\n")
+print(f"wrote {out} (source={source})")
+PY
+
+FLAG="--dry-run"
+if [[ "$MODE" == "live" ]]; then
+  FLAG="--live"
+  TOKEN="${TELEGRAM_BOT_TOKEN:-${TELEGRAM_TOKEN:-}}"
+  if [[ -z "$TOKEN" ]]; then
+    echo "WARNING: live requested but TELEGRAM_BOT_TOKEN/TELEGRAM_TOKEN unset — soft-skip"
+    echo "source=${SOURCE}" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "mode=skip" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "reason=missing-token" >> "${GITHUB_OUTPUT:-/dev/null}"
+    exit 0
+  fi
+  # Normalize for CLI (supports both names).
+  export TELEGRAM_BOT_TOKEN="$TOKEN"
+  export TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:--1004381150566}"
+  export TELEGRAM_TOPIC_ID="${TELEGRAM_TOPIC_ID:-${TELEGRAM_ALLURE_NOTIFICATIONS_TOPIC_ID:-34}}"
+fi
+
+echo "==> npx allure-notifications@${CLI_PIN} send --config ${RUNTIME_CONFIG} ${FLAG}"
+set +e
+SEND_LOG="$(mktemp)"
+npx --yes "allure-notifications@${CLI_PIN}" send \
+  --config "$RUNTIME_CONFIG" \
+  $FLAG \
+  --out "$OUT_PNG" 2>&1 | tee "$SEND_LOG"
+SEND_EXIT=${PIPESTATUS[0]}
+set -e
+
+MESSAGE_ID="$(grep -Eo 'message_id=[0-9]+' "$SEND_LOG" | head -1 | cut -d= -f2 || true)"
+{
+  echo "source=${SOURCE}"
+  echo "mode=${MODE}"
+  echo "send_exit=${SEND_EXIT}"
+  if [[ -n "${MESSAGE_ID}" ]]; then
+    echo "message_id=${MESSAGE_ID}"
+  fi
+  if [[ -f "$OUT_PNG" ]]; then
+    echo "collage=${OUT_PNG}"
+  fi
+} >> "${GITHUB_OUTPUT:-/dev/null}"
+
+if [[ "$SEND_EXIT" -ne 0 ]]; then
+  if [[ "$MODE" == "dry-run" ]]; then
+    echo "ERROR: dry-run wiring failed (exit ${SEND_EXIT}) — fix config/CLI path" >&2
+    exit "$SEND_EXIT"
+  fi
+  echo "WARNING: live send failed (exit ${SEND_EXIT}) — not a merge blocker" >&2
+  exit 0
+fi
+
+echo "OK: telegram ${MODE} (source=${SOURCE}${MESSAGE_ID:+ message_id=${MESSAGE_ID}})"


### PR DESCRIPTION
## Summary
- Add CI job `telegram` in `ci-6.0.yml` (needs `test`): PR/feature `--dry-run`; `master` + `workflow_dispatch` `--live` when `TELEGRAM_*` present; forks never live.
- `scripts/ci-telegram.sh` + `config/ci-telegram.json` prefer this run’s `allure-report`/`allure-results`, fallback dogfood CB-870; pin `npx allure-notifications@6.0.4` → topic **34**.
- Soft-skip without secrets (not a merge blocker); dry-run wiring failure fails the job. Docs: cookbook + telegram-dogfood.

## Test plan
- [ ] PR CI: job `telegram` dry-run green + optional `collage-telegram` artifact
- [ ] After merge to `master` (or `workflow_dispatch`): live `sendPhoto` in Monitoring topic 34; job summary shows `message_id`
- [ ] Fork path never passes token / never `--live`
- [ ] VERSION stays **6.0.4** (no bump)


Made with [Cursor](https://cursor.com)