### PR TITLE
feat(quality): Q5 Harden — coverage floors + SONAR_REQUIRED

### DIFF
--- a/.github/workflows/ci-6.0.yml
+++ b/.github/workflows/ci-6.0.yml
@@ -1,9 +1,10 @@
 # 6.0 TypeScript monorepo CI (master + feature/6.0* + quality contour lines).
 # Java 5.0.8 jar CI stays in build.yml (master) — do not merge jobs.
-# Q1: Allure results + generate + soft c8 coverage artifacts (no % gate).
-# Q2: Sonar upload + sonar-gate-wait (soft SONAR_REQUIRED=false).
+# Q1: Allure results + generate + c8 coverage artifacts.
+# Q2: Sonar upload + sonar-gate-wait.
 # Q3: TestOps upload+close via allurectl (informational; skip without ALLURE_*).
 # Q4: Telegram collage dry-run (PR) / live (master + workflow_dispatch; never forks).
+# Q5: Coverage % gate (lines≥70 / statements≥65) + SONAR_REQUIRED=true (forks/no token soft-skip).
 
 name: CI 6.0 (TypeScript)
 
@@ -83,7 +84,7 @@ jobs:
           ALLURE_RESULTS_DIR: ${{ github.workspace }}/allure-results
         run: pnpm test
 
-      - name: Coverage (packages, soft — no % gate)
+      - name: Coverage (packages, hard — lines≥70 / statements≥65)
         env:
           CI: true
           ALLURE_RESULTS_DIR: ${{ github.workspace }}/allure-results
@@ -120,11 +121,12 @@ jobs:
           retention-days: 7
 
   sonar:
-    name: Sonar (soft)
+    name: Sonar (hard)
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    # Forks: job still runs for visibility, but never receives SONAR_TOKEN (soft-skip in script).
+    # Same-repo + SONAR_TOKEN: gate FAILED → fail job when SONAR_REQUIRED=true.
+    # Forks / no token: soft-skip (script exits 0 even if SONAR_REQUIRED=true).
 
     steps:
       - name: Checkout
@@ -148,12 +150,12 @@ jobs:
           name: coverage
           path: coverage/
 
-      - name: Sonar scan + gate (soft)
+      - name: Sonar scan + gate
         env:
           # Never pass token on fork PRs (secrets are empty there anyway; explicit for clarity).
           SONAR_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.SONAR_TOKEN || '' }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonar.qa.guru' }}
-          SONAR_REQUIRED: ${{ vars.SONAR_REQUIRED || 'false' }}
+          SONAR_REQUIRED: ${{ vars.SONAR_REQUIRED || 'true' }}
           SONAR_PROJECT_KEY: allure-notifications
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: bash scripts/ci-sonar.sh
@@ -164,12 +166,13 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonar.qa.guru' }}
         run: |
           {
-            echo "## Sonar (soft)"
+            echo "## Sonar (hard / Q5)"
             echo ""
             echo "- projectKey: \`allure-notifications\`"
             echo "- host: \`${SONAR_HOST_URL}\`"
             echo "- dashboard: ${SONAR_HOST_URL%/}/dashboard?id=allure-notifications"
-            echo "- SONAR_REQUIRED: \`${{ vars.SONAR_REQUIRED || 'false' }}\`"
+            echo "- SONAR_REQUIRED: \`${{ vars.SONAR_REQUIRED || 'true' }}\`"
+            echo "- forks / no token: soft-skip"
             echo "- commit: \`${GITHUB_SHA:0:7}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/c8.config.json
+++ b/c8.config.json
@@ -16,5 +16,7 @@
   "extension": [".js", ".ts"],
   "all": false,
   "skip-full": false,
-  "check-coverage": false
+  "check-coverage": true,
+  "lines": 70,
+  "statements": 65
 }

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -38,7 +38,7 @@ Fixture config already points at `packages/core/test/fixtures/dogfood-report` + 
 
 ## GitHub Actions — product CI (this repo)
 
-TS tests live in [`.github/workflows/ci-6.0.yml`](../.github/workflows/ci-6.0.yml) (`pnpm i` + `pnpm typecheck` + `pnpm test` + soft `pnpm coverage` + `pnpm allure:generate` on `master` + `feature/6.0*` + `feature/quality-*`). Artifacts: `allure-results/` · `allure-report/` · `coverage/` (retain ≥7d). Job **Sonar (soft)** needs coverage → `scripts/ci-sonar.sh` + vendored `scripts/sonar-gate-wait.py` (`projectKey=allure-notifications`; `SONAR_REQUIRED=false`). Job **TestOps (informational)** needs `allure-results` → `setup-allurectl@v1` + `allurectl upload` + close (soft-skip without `ALLURE_*`; forks never upload). Job **Telegram (Q4)** needs `allure-report` → `scripts/ci-telegram.sh` + `config/ci-telegram.json` (`npx allure-notifications@6.0.4`; PR dry-run / master live → topic 34). Builder Pages: [`pages-builder.yml`](../.github/workflows/pages-builder.yml) (static `apps/builder/` on `master` + `feature/6.0*`; see [`pages-cutover.md`](pages-cutover.md)). Java jar CI stays in [`build.yml`](../.github/workflows/build.yml) (**master** only; cwd `legacy/java`).
+TS tests live in [`.github/workflows/ci-6.0.yml`](../.github/workflows/ci-6.0.yml) (`pnpm i` + `pnpm typecheck` + `pnpm test` + hard `pnpm coverage` + `pnpm allure:generate` on `master` + `feature/6.0*` + `feature/quality-*`). Artifacts: `allure-results/` · `allure-report/` · `coverage/` (retain ≥7d). Job **Sonar (hard / Q5)** needs coverage → `scripts/ci-sonar.sh` + vendored `scripts/sonar-gate-wait.py` (`projectKey=allure-notifications`; `SONAR_REQUIRED=true`; forks / no token soft-skip). Job **TestOps (informational)** needs `allure-results` → `setup-allurectl@v1` + `allurectl upload` + close (soft-skip without `ALLURE_*`; forks never upload). Job **Telegram (Q4)** needs `allure-report` → `scripts/ci-telegram.sh` + `config/ci-telegram.json` (`npx allure-notifications@6.0.4`; PR dry-run / master live → topic 34). Builder Pages: [`pages-builder.yml`](../.github/workflows/pages-builder.yml) (static `apps/builder/` on `master` + `feature/6.0*`; see [`pages-cutover.md`](pages-cutover.md)). Java jar CI stays in [`build.yml`](../.github/workflows/build.yml) (**master** only; cwd `legacy/java`).
 
 ## Own tests → Allure results (Q1)
 
@@ -52,7 +52,7 @@ This repo’s **own** test run writes Allure results for the quality contour. Se
 
 ```bash
 pnpm test                 # sets ALLURE_RESULTS_DIR=<repo>/allure-results, runs workspace tests
-pnpm coverage             # c8 → coverage/lcov.info (soft; no % gate; packages only)
+pnpm coverage             # c8 → coverage/lcov.info; fails if lines <70% or statements <65%
 pnpm allure:generate      # allure generate allure-results --output allure-report
 ```
 
@@ -60,10 +60,10 @@ Notes:
 
 - Node before 26.1: reporter-only mode (pass/fail/skip) — no `allure-js-commons` runtime API preload required. CI uses Node 20.
 - `ALLURE_RESULTS_DIR` must point at the **repo root** `allure-results/` (root `scripts/run-tests.mjs`); do not write into package cwd.
-- Coverage excludes: `dist` test emit noise, `node_modules`, `vendor`, `test/fixtures`, `apps/builder/js`, `**/*.test.*`. Soft collect only until Q5.
+- Coverage excludes: `dist` test emit noise, `node_modules`, `vendor`, `test/fixtures`, `apps/builder/js`, `**/*.test.*`. Hard floors in [`c8.config.json`](../c8.config.json) (Q5). Collage/visual pixel gate stays in `pnpm test` — not mixed with % floor.
 - Forks/PR: no live secrets needed for this path (tests + Allure generate + coverage artifact).
 
-## Sonar (Q2, soft)
+## Sonar (Q2 soft → Q5 hard)
 
 One Sonar project for the TS monorepo: **`allure-notifications`** → [dashboard](https://sonar.qa.guru/dashboard?id=allure-notifications).  
 Config: [`sonar-project.properties`](../sonar-project.properties). Coverage in: `coverage/lcov.info` (from `pnpm coverage`).  
@@ -73,15 +73,29 @@ Gate poll: vendored thin copy [`scripts/sonar-gate-wait.py`](../scripts/sonar-ga
 |--------------|------|----------------|
 | `SONAR_TOKEN` | secret | never on fork PRs |
 | `SONAR_HOST_URL` | var | `https://sonar.qa.guru` |
-| `SONAR_REQUIRED` | var | `false` until Q5 — soft-skip on missing token / host down / gate ≠ PASSED |
+| `SONAR_REQUIRED` | var | **`true`** (Q5) — gate ≠ PASSED fails job when token present; forks / no token always soft-skip |
 
 Local dry-run (no token, no upload):
 
 ```bash
 python scripts/sonar-gate-wait.py --project-key allure-notifications --dry-run
-# optional: after pnpm coverage, full soft path (skips without SONAR_TOKEN)
-SONAR_REQUIRED=false bash scripts/ci-sonar.sh
+# after pnpm coverage: skips without SONAR_TOKEN even if SONAR_REQUIRED=true
+bash scripts/ci-sonar.sh
 ```
+
+## Harden (Q5)
+
+Quality contour close-out for this repo:
+
+| Gate | Policy |
+|------|--------|
+| Coverage | **blocker** — `c8` `check-coverage`: lines ≥ **70%**, statements ≥ **65%** on `packages/{config,pyramid,core,cli}/src` |
+| Sonar | **blocker** when `SONAR_TOKEN` present + `SONAR_REQUIRED=true` and quality gate ≠ PASSED |
+| Forks / no token | Sonar **soft-skip** (exit 0); coverage still runs (no secrets needed) |
+| Visual / collage | Unchanged pixel/ahash gate in `pnpm test` — **not** part of coverage % floor |
+| TestOps / Telegram | Still informational / dry-run-on-PR as Q3–Q4 |
+
+Contour complete → next product line items: `packages/plugin`, AI (separate HQ OK).
 
 ## TestOps (Q3, informational)
 

--- a/scripts/ci-sonar.sh
+++ b/scripts/ci-sonar.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# Soft Sonar upload + quality gate poll for allure-notifications (Q2).
-# Soft-skip when: fork / no SONAR_TOKEN / host down / gate ≠ PASSED (unless SONAR_REQUIRED=true).
-# Env: SONAR_TOKEN, SONAR_HOST_URL (default https://sonar.qa.guru), SONAR_REQUIRED (default false)
+# Sonar upload + quality gate poll for allure-notifications (Q5 harden).
+# Soft-skip forever: forks / no SONAR_TOKEN.
+# When token present + SONAR_REQUIRED=true: gate ≠ PASSED / host down / missing
+# coverage → fail job. Soft (SONAR_REQUIRED=false): warn + exit 0 on those.
+# Env: SONAR_TOKEN, SONAR_HOST_URL (default https://sonar.qa.guru),
+#      SONAR_REQUIRED (default false; Q5 repo var = true)
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -11,7 +14,15 @@ export SONAR_HOST_URL="${SONAR_HOST_URL:-https://sonar.qa.guru}"
 export SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-allure-notifications}"
 export SONAR_REQUIRED="${SONAR_REQUIRED:-false}"
 
+# Always exit 0 — forks / missing token never block (even when SONAR_REQUIRED=true).
 soft_skip() {
+  local msg="$1"
+  echo "WARNING: $msg — soft-skip"
+  exit 0
+}
+
+# Fail when harden is on; otherwise soft-skip.
+required_or_soft() {
   local msg="$1"
   if [[ "$SONAR_REQUIRED" == "true" ]]; then
     echo "ERROR: $msg (SONAR_REQUIRED=true)" >&2
@@ -30,11 +41,11 @@ if [[ -z "${SONAR_TOKEN:-}" ]]; then
 fi
 
 if ! curl -sf --max-time 15 "${SONAR_HOST_URL%/}/api/system/status" >/dev/null; then
-  soft_skip "Sonar host unreachable: ${SONAR_HOST_URL}"
+  required_or_soft "Sonar host unreachable: ${SONAR_HOST_URL}"
 fi
 
 if [[ ! -f coverage/lcov.info ]]; then
-  soft_skip "coverage/lcov.info missing — run pnpm coverage / download artifact first"
+  required_or_soft "coverage/lcov.info missing — run pnpm coverage / download artifact first"
 fi
 
 echo "==> sonar-scanner → ${SONAR_HOST_URL} (${SONAR_PROJECT_KEY})"
@@ -48,7 +59,7 @@ if command -v python >/dev/null 2>&1; then
 elif command -v python3 >/dev/null 2>&1; then
   PY=python3
 else
-  soft_skip "no python for gate poll"
+  required_or_soft "no python for gate poll"
 fi
 
 set +e
@@ -63,4 +74,4 @@ if [[ $gate_ec -eq 0 ]]; then
   exit 0
 fi
 
-soft_skip "quality gate not PASSED (exit=${gate_ec})"
+required_or_soft "quality gate not PASSED (exit=${gate_ec})"

--- a/scripts/run-coverage.mjs
+++ b/scripts/run-coverage.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 /**
- * Soft coverage for packages only (Q1). Does not fail on % thresholds.
+ * Package coverage via c8 (Q5 harden).
+ * Thresholds in c8.config.json: lines ≥70%, statements ≥65% on
+ * packages/{config,pyramid,core,cli}/src (excludes dist/fixtures/vendor/tests).
+ * Collage/visual pixel gate stays in `pnpm test` — not mixed with % floor.
  * Writes Allure sidecar to .coverage-allure-tmp so it does not pollute
  * the primary allure-results/ from `pnpm test`.
  */


### PR DESCRIPTION
## Summary
- **Coverage hard gate:** `c8.config.json` `check-coverage` — lines ≥70%, statements ≥65% on `packages/{config,pyramid,core,cli}/src` (same excludes as Q1). Baseline ~**92%** lines/statements — no staged floor needed. Collage/visual pixel gate stays in `pnpm test`.
- **Sonar hard:** GH var `SONAR_REQUIRED=true`; workflow default `true`. Gate ≠ PASSED fails the job when `SONAR_TOKEN` is present. Forks / no token always soft-skip (`scripts/ci-sonar.sh`).
- **Docs:** nested `docs/ci-cookbook.md` Harden (Q5) section.

## Test plan
- [x] Local `pnpm coverage` green with thresholds (~92% stmts/lines)
- [x] `IS_FORK=true SONAR_REQUIRED=true bash scripts/ci-sonar.sh` → exit 0
- [x] No token + `SONAR_REQUIRED=true` → exit 0
- [ ] CI on this PR: `pnpm test` + coverage hard + Sonar scan/gate with secrets
- [ ] Confirm job summary shows `SONAR_REQUIRED: true`

VERSION **6.0.4** untouched. Out of scope: plugin, AI, Matrix, legacy/java, visual-gate CANON thresholds.


Made with [Cursor](https://cursor.com)