### PR TITLE
feat(plugin): Allure 3 thin plugin over core (Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased (propose **6.0.5**)
+
+### English
+
+- **Allure 3 plugin** — `@allure-notifications/plugin` (`packages/plugin`): `Plugin.done` → parseConfig → core collage PNG → CLI messengers; `mode` dry-run|mock|live (default dry-run); example `examples/allurerc.notifications.mjs`
+
+### Russian
+
+- **Allure 3 plugin** — `@allure-notifications/plugin` (`packages/plugin`): `Plugin.done` → parseConfig → collage PNG (core) → messengers (CLI); `mode` dry-run|mock|live (default dry-run); пример `examples/allurerc.notifications.mjs`
+
 ## v 6.0.3
 
 ### English

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,9 +12,9 @@ There is **no 5.1** line. Historical Java A3 MVP stays at **5.0.8**; product con
 |------|--------|-------|--------|
 | **4.\*** | Allure 2 | Java | Historical A2 |
 | **5.\*** | Allure 3 | Java MVP (Gradle fat jar **5.0.8**) | **Historical build** under [`legacy/java/`](legacy/java/) — **keep forever**; bugfix / security only; **no TypeScript**; **do not delete** |
-| **6.\*** | Allure 3 | TypeScript / typescript-go · CLI · builder · A3 plugin · AI | **Product** on `master` — pin `docs/allure-notifications/VERSION` (**6.0.3** CLI) |
+| **6.\*** | Allure 3 | TypeScript / typescript-go · CLI · builder · A3 plugin · AI | **Product** on `master` — pin `docs/allure-notifications/VERSION` (**6.0.4** CLI) |
 
-Monorepo pin = **6.0.3**. Product packages: npm **`allure-notifications`** + scoped `@allure-notifications/*`.
+Monorepo pin = **6.0.4**. Product packages: npm **`allure-notifications`** + scoped `@allure-notifications/*` (plugin ships with next publish / **6.0.5**).
 
 ## Public product 6.\* (locked)
 
@@ -76,7 +76,7 @@ Java **5.0.8** Gradle multi-module lives under [`legacy/java/`](legacy/java/) (`
 | **2** | `packages/pyramid` — palette + geometry SSOT (not dashboard-overrides) | **done** |
 | **3** | `packages/core` + `cli` — native PNG, Telegram, dogfood, cookbooks; public **6.0.0** | **done** (core + cli dry-run/mock + live Telegram `--live` / ADR 008 dogfood) |
 | **4** | Builder import `@config` (browser SSOT); optional `@pyramid`; full TS / typescript@7 | **done** (`@config` + `@pyramid` import map → vendor sync); **full TS done** (`apps/builder/src` → emit `js/`, toolchain `typescript@7`) |
-| **5** | Thin `@allurereport/plugin-api` wrapper over `core` (`packages/plugin`) | **planned** (in-line for 6.\*, not optional forever) |
+| **5** | Thin `@allurereport/plugin-api` wrapper over `core` (`packages/plugin`) | **done** (`@allure-notifications/plugin` — `done` hook; dry-run default) |
 
 ## Anti-hack rules
 
@@ -200,6 +200,18 @@ See [docs/ci-cookbook.md](docs/ci-cookbook.md): `allure generate` → `allure-no
 - **Manual (GitHub UI):** enable Pages source = GitHub Actions; smoke on `qa-guru.github.io/allure-notifications/`; then move custom domain off `allure-notifications-builder` onto this repo ([`docs/pages-cutover.md`](docs/pages-cutover.md)).
 - Archive second repo = **after** domain cutover + separate HQ OK (checklist row 4).
 
+## Phase 5 notes (Allure 3 plugin)
+
+`@allure-notifications/plugin` (`packages/plugin/`):
+
+- Implements `@allurereport/plugin-api` `Plugin.done` (etalon: `@allurereport/plugin-slack`)
+- Pipeline: `parseConfig` → `loadReportAnalytics` / `renderCollagePng` (`@allure-notifications/core`, `@napi-rs/canvas`) → `deliver` (CLI messengers)
+- Options: `config` (path or inline), `mode: "dry-run" | "mock" | "live"` (**default dry-run**, no network), optional `out` / `reportFile`
+- Example: [`examples/allurerc.notifications.mjs`](examples/allurerc.notifications.mjs)
+- Tests: fixture dry-run → PNG + dry-run messenger (no network)
+- Verify: `pnpm --filter @allure-notifications/plugin test` / root `pnpm test` + `pnpm typecheck`
+- **Not in Phase 5:** npm publish / VERSION bump (propose **6.0.5**), AI features
+
 ## Next
 
-Post-G gaps: Pages **domain** cutover + archive (workflow ready); VERSION cutover. Telegram dogfood **done**. Do not bump pin without HQ.
+Phase 5 **done**. Open: AI features (by OK); npm publish plugin with **6.0.5** (HQ OK). Do not bump pin without HQ.

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -89,13 +89,13 @@ Quality contour close-out for this repo:
 
 | Gate | Policy |
 |------|--------|
-| Coverage | **blocker** — `c8` `check-coverage`: lines ≥ **70%**, statements ≥ **65%** on `packages/{config,pyramid,core,cli}/src` |
+| Coverage | **blocker** — `c8` `check-coverage`: lines ≥ **70%**, statements ≥ **65%** on `packages/{config,pyramid,core,cli,plugin}/src` |
 | Sonar | **blocker** when `SONAR_TOKEN` present + `SONAR_REQUIRED=true` and quality gate ≠ PASSED |
 | Forks / no token | Sonar **soft-skip** (exit 0); coverage still runs (no secrets needed) |
 | Visual / collage | Unchanged pixel/ahash gate in `pnpm test` — **not** part of coverage % floor |
 | TestOps / Telegram | Still informational / dry-run-on-PR as Q3–Q4 |
 
-Contour complete → next product line items: `packages/plugin`, AI (separate HQ OK).
+Contour complete. Phase 5 plugin **done** (`@allure-notifications/plugin` — see `examples/allurerc.notifications.mjs`). Next product: AI (separate HQ OK); npm publish plugin → **6.0.5**.
 
 ## TestOps (Q3, informational)
 
@@ -210,7 +210,7 @@ Live messenger send (token in credentials) is out of band until ADR 008 dogfood 
 |-------|-----|
 | `java -jar allure-notifications-*.jar` on 6.0 path | Legacy 5.0 only |
 | Jenkins Plugin Manager install | Not a Jenkins plugin |
-| Allure 3 plugin install for notify | CLI is the entrypoint; optional thin plugin = Phase 5 |
+| Allure 3 plugin as sole CI path | CLI remains primary; plugin = optional `allurerc` (`@allure-notifications/plugin`, Phase 5 done) |
 | HTML inject / `dashboard-overrides` in CI | Private zds stack only — not npm product |
 | Playwright for production PNG | Playwright = builder e2e only; collage = `@napi-rs/canvas` |
 

--- a/examples/allurerc.notifications.mjs
+++ b/examples/allurerc.notifications.mjs
@@ -1,0 +1,29 @@
+/**
+ * Example allurerc — Allure 3 + @allure-notifications/plugin (Phase 5).
+ *
+ * Usage (after `pnpm add allure @allure-notifications/plugin`):
+ *   npx allure generate ./allure-results --config ./examples/allurerc.notifications.mjs
+ *
+ * Default mode is dry-run (collage + messenger plan, no network).
+ * Set mode: "live" only with TELEGRAM_* credentials (ADR 008).
+ */
+import { defineConfig } from "allure";
+
+export default defineConfig({
+  name: "Allure Report",
+  output: "./allure-report",
+  plugins: {
+    awesome: {},
+    notifications: {
+      import: "@allure-notifications/plugin",
+      options: {
+        // Same JSON schema as: npx allure-notifications send --config …
+        config: "./config/ci-telegram.json",
+        mode: "dry-run",
+        // mode: "mock",
+        // mode: "live",
+        // out: "./collage.png",
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "node scripts/run-tests.mjs",
     "coverage": "node scripts/run-coverage.mjs",
     "allure:generate": "rm -rf allure-report && allure generate allure-results --output allure-report",
-    "publish:packages": "pnpm --filter @allure-notifications/config --filter @allure-notifications/pyramid --filter @allure-notifications/core --filter allure-notifications publish --access public --no-git-checks",
+    "publish:packages": "pnpm --filter @allure-notifications/config --filter @allure-notifications/pyramid --filter @allure-notifications/core --filter allure-notifications --filter @allure-notifications/plugin publish --access public --no-git-checks",
     "typecheck": "pnpm -r run typecheck"
   },
   "devDependencies": {

--- a/packages/plugin/.gitignore
+++ b/packages/plugin/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,0 +1,55 @@
+# @allure-notifications/plugin
+
+Allure 3 **plugin** for line **6.0.\*** — thin wrapper over `@allure-notifications/core` + CLI messengers.
+
+Etalon: [`@allurereport/plugin-slack`](https://github.com/allure-framework/allure3/blob/main/packages/plugin-slack/src/plugin.ts) `done` hook.
+
+## Install
+
+```bash
+npm add @allure-notifications/plugin
+# workspace: already in pnpm packages/plugin
+```
+
+## allurerc
+
+```js
+import { defineConfig } from "allure";
+
+export default defineConfig({
+  name: "Allure Report",
+  output: "./allure-report",
+  plugins: {
+    awesome: {},
+    notifications: {
+      import: "@allure-notifications/plugin",
+      options: {
+        config: "./config/notifications.json",
+        mode: "dry-run", // "dry-run" | "mock" | "live" — default dry-run
+      },
+    },
+  },
+});
+```
+
+Full example: [`examples/allurerc.notifications.mjs`](../../examples/allurerc.notifications.mjs).
+
+## Options
+
+| Option | Type | Default | Role |
+|--------|------|---------|------|
+| `config` | `string \| object` | **required** | Path to `config.json` or inline CLI schema |
+| `mode` | `"dry-run" \| "mock" \| "live"` | `dry-run` | Messengers; live = Telegram ADR 008 |
+| `out` | `string` | — | Write collage PNG to disk |
+| `allureFolder` | `string` | `context.output` if unset in config | Report dir for summary |
+| `allureResultsFolder` | `string` | from config | Results for analytics |
+| `reportFile` | `string \| false` | `allure-notifications-collage.png` | Attach PNG into report; `false` to skip |
+
+Pipeline in `done`: `parseConfig` → `loadReportAnalytics` / `renderCollagePng` (core, `@napi-rs/canvas`) → `deliver` (CLI messengers). **No network** unless `mode: "live"`.
+
+## Verify
+
+```bash
+pnpm --filter @allure-notifications/plugin test
+pnpm --filter @allure-notifications/plugin typecheck
+```

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@allure-notifications/plugin",
+  "version": "6.0.4",
+  "description": "Allure 3 plugin — thin wrapper over core + CLI messengers (Phase 5).",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
+  "files": [
+    "dist/src",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qa-guru/allure-notifications.git",
+    "directory": "packages/plugin"
+  },
+  "homepage": "https://github.com/qa-guru/allure-notifications#readme",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm run build && node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=allure-node-test/reporter --test-reporter-destination=stdout dist/test/*.test.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm run build"
+  },
+  "dependencies": {
+    "@allure-notifications/config": "workspace:*",
+    "@allure-notifications/core": "workspace:*",
+    "@allurereport/plugin-api": "^3.14.3",
+    "allure-notifications": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "allure-node-test": "3.10.2",
+    "typescript": "^7.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "allure",
+    "plugin",
+    "notifications",
+    "telegram",
+    "testing"
+  ]
+}

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @allure-notifications/plugin — Allure 3 plugin (Phase 5).
+ *
+ * Thin wrapper: parseConfig → loadReportAnalytics / renderCollagePng → CLI messengers.
+ * Default export matches @allurereport/plugin-slack etalon for allurerc `import`.
+ */
+
+export {
+  NotificationsPlugin as default,
+  NotificationsPlugin,
+  PACKAGE,
+  PHASE,
+  runNotificationsPlugin,
+  type NotificationsPluginMode,
+  type NotificationsPluginOptions,
+  type NotificationsPluginResult,
+} from "./plugin.js";

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -1,0 +1,234 @@
+/**
+ * Allure 3 plugin — thin wrapper over config/core + CLI messengers.
+ *
+ * Etalon: @allurereport/plugin-slack `done` hook.
+ * Collage PNG via @napi-rs/canvas (core); never Playwright.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+import { parseConfig, type Config } from "@allure-notifications/config";
+import {
+  loadReportAnalytics,
+  renderCollagePng,
+  type ReportAnalytics,
+} from "@allure-notifications/core";
+import type { AllureStore, Plugin, PluginContext } from "@allurereport/plugin-api";
+import {
+  deliver,
+  resolveConfigPaths,
+  type DeliveryResult,
+} from "allure-notifications";
+
+export const PACKAGE = "@allure-notifications/plugin";
+export const PHASE = 5;
+
+export type NotificationsPluginMode = "dry-run" | "mock" | "live";
+
+export type NotificationsPluginOptions = {
+  /**
+   * Path to `config.json` (relative to `cwd`) or inline config object.
+   * Same schema as CLI `send --config`.
+   */
+  config: string | Record<string, unknown>;
+  /**
+   * Delivery mode. Default: `dry-run` (no network).
+   * `live` → Telegram sendPhoto (ADR 008) via CLI messengers.
+   */
+  mode?: NotificationsPluginMode;
+  /** Write collage PNG to disk. */
+  out?: string;
+  /**
+   * Override `base.allureFolder`. When omitted and config has no folder,
+   * falls back to `PluginContext.output` (Allure report dir).
+   */
+  allureFolder?: string;
+  /** Override `base.allureResultsFolder`. */
+  allureResultsFolder?: string;
+  /** Attach collage into the generated report as this relative path. */
+  reportFile?: string | false;
+  /** Override cwd for relative path resolution (tests). */
+  cwd?: string;
+  /** Env override for credential resolution / tests. */
+  env?: NodeJS.ProcessEnv;
+  /** Injectable fetch for live unit tests. */
+  fetchImpl?: typeof fetch;
+};
+
+export type NotificationsPluginResult = {
+  config: Config;
+  png: Buffer;
+  pngPath?: string;
+  deliveries: DeliveryResult[];
+  mode: NotificationsPluginMode;
+  analytics: ReportAnalytics;
+};
+
+function resolveMaybeRelative(
+  value: string | undefined,
+  baseDir: string,
+): string | undefined {
+  if (value == null || !value.trim()) {
+    return value;
+  }
+  if (isAbsolute(value)) {
+    return value;
+  }
+  return resolve(baseDir, value);
+}
+
+function effectiveMode(mode: NotificationsPluginMode | undefined): {
+  mode: NotificationsPluginMode;
+  dryRun: boolean;
+  mock: boolean;
+  live: boolean;
+} {
+  const resolved: NotificationsPluginMode =
+    mode === "mock" || mode === "live" ? mode : "dry-run";
+  return {
+    mode: resolved,
+    dryRun: resolved === "dry-run",
+    mock: resolved === "mock",
+    live: resolved === "live",
+  };
+}
+
+type ZodLikeIssue = { path: PropertyKey[]; message: string };
+
+function isZodLikeError(err: unknown): err is { issues: ZodLikeIssue[] } {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "issues" in err &&
+    Array.isArray((err as { issues: unknown }).issues)
+  );
+}
+
+function formatConfigValidationError(err: unknown, label: string): Error {
+  if (isZodLikeError(err)) {
+    const lines = err.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `  - ${path}: ${issue.message}`;
+    });
+    return new Error(`invalid config ${label}:\n${lines.join("\n")}`);
+  }
+  if (err instanceof Error) {
+    return err;
+  }
+  return new Error(String(err));
+}
+
+async function loadPluginConfig(
+  options: NotificationsPluginOptions,
+  cwd: string,
+): Promise<Config> {
+  const raw = options.config;
+  if (typeof raw === "string") {
+    const configPath = isAbsolute(raw) ? raw : resolve(cwd, raw);
+    const text = await readFile(configPath, "utf8");
+    let data: unknown;
+    try {
+      data = JSON.parse(text);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`invalid JSON in ${configPath}: ${msg}`);
+    }
+    try {
+      return resolveConfigPaths(parseConfig(data), dirname(configPath));
+    } catch (err) {
+      throw formatConfigValidationError(err, configPath);
+    }
+  }
+
+  try {
+    return resolveConfigPaths(parseConfig(raw), cwd);
+  } catch (err) {
+    throw formatConfigValidationError(err, "(inline options.config)");
+  }
+}
+
+function applyFolderOverrides(
+  config: Config,
+  options: NotificationsPluginOptions,
+  context: PluginContext,
+  cwd: string,
+): Config {
+  const base = { ...config.base };
+  const allureFolder =
+    resolveMaybeRelative(options.allureFolder, cwd) ??
+    base.allureFolder ??
+    context.output;
+  const allureResultsFolder =
+    resolveMaybeRelative(options.allureResultsFolder, cwd) ??
+    base.allureResultsFolder;
+
+  if (allureFolder) {
+    base.allureFolder = allureFolder;
+  }
+  if (allureResultsFolder) {
+    base.allureResultsFolder = allureResultsFolder;
+  }
+  return { ...config, base };
+}
+
+/**
+ * Parse config → collage PNG (core) → messengers (CLI). Safe default = dry-run.
+ */
+export async function runNotificationsPlugin(
+  context: PluginContext,
+  options: NotificationsPluginOptions,
+): Promise<NotificationsPluginResult> {
+  if (options.config == null) {
+    throw new Error(
+      `${PACKAGE}: options.config is required (path or inline object)`,
+    );
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const { mode, dryRun, mock, live } = effectiveMode(options.mode);
+
+  let config = await loadPluginConfig(options, cwd);
+  config = applyFolderOverrides(config, options, context, cwd);
+
+  const analytics = await loadReportAnalytics(config);
+  const png = await renderCollagePng(config, analytics);
+
+  let pngPath: string | undefined;
+  if (options.out) {
+    pngPath = isAbsolute(options.out) ? options.out : resolve(cwd, options.out);
+    await writeFile(pngPath, png);
+  }
+
+  if (options.reportFile !== false) {
+    const reportName =
+      typeof options.reportFile === "string" && options.reportFile.trim()
+        ? options.reportFile.trim()
+        : "allure-notifications-collage.png";
+    await context.reportFiles.addFile(reportName, png);
+  }
+
+  const deliveries = await deliver(config, {
+    dryRun,
+    mock,
+    live,
+    png,
+    pngBytes: png.byteLength,
+    analytics,
+    env: options.env,
+    fetchImpl: options.fetchImpl,
+  });
+
+  return { config, png, pngPath, deliveries, mode, analytics };
+}
+
+export class NotificationsPlugin implements Plugin {
+  constructor(readonly options: NotificationsPluginOptions) {}
+
+  done = async (
+    context: PluginContext,
+    _store: AllureStore,
+  ): Promise<void> => {
+    await runNotificationsPlugin(context, this.options);
+  };
+}

--- a/packages/plugin/test/fixtures/config.dry-run.json
+++ b/packages/plugin/test/fixtures/config.dry-run.json
@@ -1,0 +1,32 @@
+{
+  "base": {
+    "project": "plugin-phase-5-dry-run",
+    "environment": "test",
+    "language": "en",
+    "allureFolder": "../../../core/test/fixtures/dogfood-report",
+    "allureResultsFolder": "../../../core/test/fixtures/dogfood-results",
+    "enableChart": true,
+    "darkMode": true,
+    "chart": {
+      "mode": "collage",
+      "layout": "free",
+      "width": 870,
+      "height": 1080,
+      "headerHeight": 68,
+      "cardGap": 14,
+      "gridCols": 10,
+      "gridRows": 10,
+      "items": [
+        { "type": "pie", "x": 0, "y": 0, "w": 5, "h": 5 },
+        { "type": "testingPyramid", "x": 5, "y": 0, "w": 5, "h": 5 },
+        { "type": "durations", "x": 0, "y": 5, "w": 10, "h": 5 }
+      ],
+      "pyramidFallback": "suites"
+    }
+  },
+  "telegram": {
+    "token": "0:phase-5-no-send",
+    "chat": "0",
+    "templatePath": "/templates/telegram.ftl"
+  }
+}

--- a/packages/plugin/test/plugin.test.ts
+++ b/packages/plugin/test/plugin.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+import type { AllureStore, PluginContext } from "@allurereport/plugin-api";
+
+import NotificationsPlugin, {
+  PACKAGE,
+  PHASE,
+  runNotificationsPlugin,
+} from "../src/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+/** Compiled at packages/plugin/dist/test → fixtures at packages/plugin/test/fixtures */
+const FIXTURE_CONFIG = join(
+  __dirname,
+  "../../test/fixtures/config.dry-run.json",
+);
+
+function isPng(buf: Buffer): boolean {
+  return (
+    buf.length >= 8 &&
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47
+  );
+}
+
+function mockContext(overrides: Partial<PluginContext> = {}): {
+  context: PluginContext;
+  files: Map<string, Buffer>;
+} {
+  const files = new Map<string, Buffer>();
+  const context: PluginContext = {
+    id: "notifications",
+    publish: false,
+    state: {
+      set: async () => undefined,
+      get: async <T>(_key: string): Promise<T> => undefined as T,
+      unset: async () => undefined,
+    },
+    allureVersion: "3.14.3",
+    reportUuid: "test-uuid",
+    reportName: "plugin-dry-run",
+    reportFiles: {
+      addFile: async (path, data) => {
+        files.set(path, data);
+        return path;
+      },
+    },
+    output: join(tmpdir(), "an-plugin-unused-output"),
+    ...overrides,
+  };
+  return { context, files };
+}
+
+const emptyStore = {} as AllureStore;
+
+describe("@allure-notifications/plugin package", () => {
+  it("exports Phase 5 identity", () => {
+    assert.equal(PACKAGE, "@allure-notifications/plugin");
+    assert.equal(PHASE, 5);
+  });
+
+  it("default export is NotificationsPlugin class", () => {
+    const plugin = new NotificationsPlugin({ config: FIXTURE_CONFIG });
+    assert.equal(typeof plugin.done, "function");
+  });
+});
+
+describe("@allure-notifications/plugin done dry-run", () => {
+  it("renders PNG from fixture config and dry-runs messengers (no network)", async () => {
+    const { context, files } = mockContext();
+    const result = await runNotificationsPlugin(context, {
+      config: FIXTURE_CONFIG,
+      mode: "dry-run",
+    });
+
+    assert.ok(isPng(result.png), "expected PNG magic bytes");
+    assert.ok(result.png.byteLength > 1000);
+    assert.equal(result.mode, "dry-run");
+    assert.equal(result.deliveries[0]!.messenger, "telegram");
+    assert.equal(result.deliveries[0]!.status, "dry-run");
+    assert.match(result.deliveries[0]!.detail, /no network/);
+    assert.equal(result.pngPath, undefined);
+
+    assert.ok(files.has("allure-notifications-collage.png"));
+    assert.ok(isPng(files.get("allure-notifications-collage.png")!));
+  });
+
+  it("defaults mode to dry-run when omitted", async () => {
+    const { context } = mockContext();
+    const result = await runNotificationsPlugin(context, {
+      config: FIXTURE_CONFIG,
+    });
+    assert.equal(result.mode, "dry-run");
+    assert.equal(result.deliveries[0]!.status, "dry-run");
+  });
+
+  it("writes PNG to out path in mock mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "an-plugin-"));
+    const out = join(dir, "collage.png");
+    try {
+      const { context } = mockContext();
+      const result = await runNotificationsPlugin(context, {
+        config: FIXTURE_CONFIG,
+        mode: "mock",
+        out,
+        reportFile: false,
+      });
+      assert.equal(result.mode, "mock");
+      assert.equal(result.pngPath, out);
+      assert.equal(result.deliveries[0]!.status, "mocked");
+      const onDisk = await readFile(out);
+      assert.ok(isPng(onDisk));
+      assert.equal(onDisk.byteLength, result.png.byteLength);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts inline config object", async () => {
+    const raw = JSON.parse(await readFile(FIXTURE_CONFIG, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const { context } = mockContext();
+    const result = await runNotificationsPlugin(context, {
+      config: raw,
+      cwd: dirname(FIXTURE_CONFIG),
+      reportFile: false,
+    });
+    assert.ok(isPng(result.png));
+    assert.equal(result.mode, "dry-run");
+  });
+
+  it("Plugin.done completes without throw (etalon hook)", async () => {
+    const plugin = new NotificationsPlugin({
+      config: FIXTURE_CONFIG,
+      mode: "dry-run",
+      reportFile: false,
+    });
+    const { context } = mockContext();
+    await plugin.done!(context, emptyStore);
+  });
+});

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022"
+    ],
+    "rootDir": ".",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,31 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  packages/plugin:
+    dependencies:
+      '@allure-notifications/config':
+        specifier: workspace:*
+        version: link:../config
+      '@allure-notifications/core':
+        specifier: workspace:*
+        version: link:../core
+      '@allurereport/plugin-api':
+        specifier: ^3.14.3
+        version: 3.14.3
+      allure-notifications:
+        specifier: workspace:*
+        version: link:../cli
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.20.1
+      allure-node-test:
+        specifier: 3.10.2
+        version: 3.10.2(allure-playwright@3.10.2(@playwright/test@1.62.0))
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   packages/pyramid:
     devDependencies:
       '@types/node':

--- a/scripts/run-coverage.mjs
+++ b/scripts/run-coverage.mjs
@@ -2,7 +2,7 @@
 /**
  * Package coverage via c8 (Q5 harden).
  * Thresholds in c8.config.json: lines ≥70%, statements ≥65% on
- * packages/{config,pyramid,core,cli}/src (excludes dist/fixtures/vendor/tests).
+ * packages/{config,pyramid,core,cli,plugin}/src (excludes dist/fixtures/vendor/tests).
  * Collage/visual pixel gate stays in `pnpm test` — not mixed with % floor.
  * Writes Allure sidecar to .coverage-allure-tmp so it does not pollute
  * the primary allure-results/ from `pnpm test`.
@@ -31,6 +31,8 @@ const result = spawnSync(
     "@allure-notifications/core",
     "--filter",
     "allure-notifications",
+    "--filter",
+    "@allure-notifications/plugin",
     "run",
     "test",
   ],


### PR DESCRIPTION
## Summary
- Add `@allure-notifications/plugin` — thin Allure 3 `Plugin.done` wrapper (etalon `@allurereport/plugin-slack`): `parseConfig` → `loadReportAnalytics` / `renderCollagePng` (core) → CLI `deliver`
- Modes: `dry-run` | `mock` | `live` (default **dry-run**, no network); example `examples/allurerc.notifications.mjs`; fixture dry-run PNG tests
- Docs: MIGRATION Phase 5 **done**; coverage filter includes plugin; **no** VERSION bump / publish (propose **6.0.5**)

## Test plan
- [x] `pnpm typecheck` green
- [x] `pnpm test` green (incl. `@allure-notifications/plugin` 7/7)
- [x] `pnpm coverage` green (floors intact; plugin ~85%)
- [ ] CI `ci-6.0.yml` on PR
- [ ] After merge: HQ OK → bump/publish **6.0.5** (plugin + scoped packages)


Made with [Cursor](https://cursor.com)