### PR TITLE
docs(plugin): 6.0.5 prep — README, allurerc, publish order

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -99,7 +99,7 @@ Java **5.0.8** Gradle multi-module lives under [`legacy/java/`](legacy/java/) (`
 
 ## CI surface
 
-See [docs/ci-cookbook.md](docs/ci-cookbook.md): `allure generate` → `allure-notifications send --config … --dry-run`. No `java -jar` on the 6.0 path.
+See [docs/ci-cookbook.md](docs/ci-cookbook.md): **primary** = `allure generate` → `allure-notifications send --config … --dry-run`. **Alternate** = Allure 3 plugin in `allurerc` ([`examples/allurerc.notifications.mjs`](examples/allurerc.notifications.mjs) · [`packages/plugin/README.md`](packages/plugin/README.md)). No `java -jar` on the 6.0 path.
 
 - **6.0 TS:** [`.github/workflows/ci-6.0.yml`](.github/workflows/ci-6.0.yml) — `pnpm install` + `pnpm typecheck` (`typescript@7`) + `pnpm test` on `master` + `feature/6.0*` + `feature/builder-ts` (Playwright Chromium for `apps/builder` e2e).
 - **Builder Pages:** [`.github/workflows/pages-builder.yml`](.github/workflows/pages-builder.yml) — build `apps/builder` TS → `js/`, sync vendor, deploy static (`index` / `css` / `js` / `vendor`) on `master` + `feature/6.0*` + `feature/builder-ts`; no Telegram secrets. Cutover runbook: [`docs/pages-cutover.md`](docs/pages-cutover.md).
@@ -214,4 +214,4 @@ See [docs/ci-cookbook.md](docs/ci-cookbook.md): `allure generate` → `allure-no
 
 ## Next
 
-Phase 5 **done**. Open: AI features (by OK); npm publish plugin with **6.0.5** (HQ OK). Do not bump pin without HQ.
+Phase 5 **done** + docs prep for plugin consumers. **Next = release 6.0.5** (npm publish plugin + pin bump), then AI features (by OK). Do not bump `VERSION` / publish without HQ.

--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ npx allure generate allure-results --clean -o allure-report
 npx allure-notifications send --config config.json --live
 ```
 
-| Piece | 6.0.0 |
+| Piece | 6.0.* |
 |-------|--------|
-| Entrypoint | `npx allure-notifications` / `pnpm exec allure-notifications` |
+| Entrypoint (primary) | `npx allure-notifications` / `pnpm exec allure-notifications` |
 | Collage PNG | `@napi-rs/canvas` in `@allure-notifications/core` (Playwright = tests only) |
 | Config builder | `apps/builder/` → [allure-notifications.qa.guru](https://allure-notifications.qa.guru/) |
-| Packages | `@allure-notifications/config` · `pyramid` · `core` · bin package `allure-notifications` |
+| Packages | `@allure-notifications/config` · `pyramid` · `core` · bin `allure-notifications` · **plugin** `@allure-notifications/plugin` |
+| Allure 3 plugin (alternate) | `done` hook via [`examples/allurerc.notifications.mjs`](examples/allurerc.notifications.mjs) — see [`packages/plugin/README.md`](packages/plugin/README.md) |
 | Java **5.0.8** | Remains under [`legacy/java/`](legacy/java/) — bugfix/security only |
 
-Docs: [`docs/ci-cookbook.md`](docs/ci-cookbook.md) · [`docs/npm-publish.md`](docs/npm-publish.md) · Telegram dogfood [`docs/telegram-dogfood.md`](docs/telegram-dogfood.md).
+Docs: [`docs/ci-cookbook.md`](docs/ci-cookbook.md) · [`docs/npm-publish.md`](docs/npm-publish.md) · Telegram dogfood [`docs/telegram-dogfood.md`](docs/telegram-dogfood.md) · Migration [`MIGRATION.md`](MIGRATION.md).
 
 ## Visual canon (5.0.3)
 

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -5,9 +5,10 @@ Public surface after Phase 3 / Stages C–D: CLI `send --config` renders a nativ
 ## Contract
 
 1. Generate Allure 3 report (or point `base.allureFolder` / `base.allureResultsFolder` at existing artifacts).
-2. Run **allure-notifications** as a separate post-step with `config.json`.
+2. **Primary:** run **allure-notifications CLI** as a separate post-step with `config.json`.
 3. CLI reads report summary/results → collage PNG → messenger(s).
 4. CLI does **not** patch awesome/dashboard HTML.
+5. **Alternate (after generate):** Allure 3 plugin via `allurerc` — [`examples/allurerc.notifications.mjs`](../examples/allurerc.notifications.mjs) · [`packages/plugin/README.md`](../packages/plugin/README.md). Same config schema / modes; not required for consumers.
 
 ```bash
 npx allure generate allure-results --clean -o allure-report
@@ -21,7 +22,24 @@ npx allure-notifications send --config config.json --dry-run
 | `--mock` | Render PNG; mock deliveries; **no network** |
 | `--out <png>` | Write PNG buffer to disk |
 
-Default without `--mock` / `--live` is safe **dry-run**. Live Telegram = explicit `--live` + env credentials ([`telegram-dogfood.md`](telegram-dogfood.md)). Product CI job **`telegram`** in `ci-6.0.yml` (Q4): PR `--dry-run`; `master` / `workflow_dispatch` `--live` when secrets present.
+Default without `--mock` / `--live` is safe **dry-run**. Live Telegram = explicit `--live` + env credentials ([`telegram-dogfood.md`](telegram-dogfood.md)). Product CI job **`telegram`** in `ci-6.0.yml` (Q4): PR `--dry-run`; `master` / `workflow_dispatch` `--live` when secrets present. CLI pin SSOT: monorepo `docs/allure-notifications/VERSION` (**6.0.4** until release **6.0.5**).
+
+### Alternate — Allure 3 plugin (`allurerc`)
+
+Use when notifications should run **inside** `allure generate` (plugin `done` hook), not as a separate shell step:
+
+```bash
+npx allure generate ./allure-results --config ./examples/allurerc.notifications.mjs
+```
+
+| | CLI (primary) | Plugin (alternate) |
+|--|---------------|--------------------|
+| Invoke | `npx allure-notifications send --config …` | `plugins.notifications` in `allurerc` |
+| Safe default | `--dry-run` | `mode: "dry-run"` |
+| Live | `--live` + `TELEGRAM_*` | `mode: "live"` + same env |
+| Config | `config.json` | `options.config` → same schema |
+
+npm `@allure-notifications/plugin` publishes with **6.0.5** (404 until then). Keep consumer CI on the CLI pin until that release.
 
 ## Workspace (local / before `npx`)
 
@@ -95,7 +113,7 @@ Quality contour close-out for this repo:
 | Visual / collage | Unchanged pixel/ahash gate in `pnpm test` — **not** part of coverage % floor |
 | TestOps / Telegram | Still informational / dry-run-on-PR as Q3–Q4 |
 
-Contour complete. Phase 5 plugin **done** (`@allure-notifications/plugin` — see `examples/allurerc.notifications.mjs`). Next product: AI (separate HQ OK); npm publish plugin → **6.0.5**.
+Contour complete. Phase 5 plugin **done** (docs + example wired; npm publish → **6.0.5**). Next product after release: AI (separate HQ OK).
 
 ## TestOps (Q3, informational)
 
@@ -210,7 +228,7 @@ Live messenger send (token in credentials) is out of band until ADR 008 dogfood 
 |-------|-----|
 | `java -jar allure-notifications-*.jar` on 6.0 path | Legacy 5.0 only |
 | Jenkins Plugin Manager install | Not a Jenkins plugin |
-| Allure 3 plugin as sole CI path | CLI remains primary; plugin = optional `allurerc` (`@allure-notifications/plugin`, Phase 5 done) |
+| Allure 3 plugin as sole CI path | CLI remains primary; plugin = optional `allurerc` after `allure generate` (see § Alternate) |
 | HTML inject / `dashboard-overrides` in CI | Private zds stack only — not npm product |
 | Playwright for production PNG | Playwright = builder e2e only; collage = `@napi-rs/canvas` |
 

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -1,4 +1,4 @@
-# npm publish — 6.0.0
+# npm publish — 6.0.*
 
 Publishable surface (not private):
 
@@ -8,6 +8,7 @@ Publishable surface (not private):
 | `packages/pyramid` | `@allure-notifications/pyramid` | palette / geometry |
 | `packages/core` | `@allure-notifications/core` | collage PNG (`@napi-rs/canvas`) |
 | `packages/cli` | **`allure-notifications`** | public bin → `npx allure-notifications` |
+| `packages/plugin` | `@allure-notifications/plugin` | Allure 3 thin plugin (Phase 5) — first public cut with **6.0.5** |
 
 Root workspace package is `@allure-notifications/monorepo` (**private** — not published). `apps/builder` stays private (Pages, not npm).
 
@@ -36,7 +37,7 @@ npm (2025+) rejects publish without **2FA on the account** or a **granular acces
        or: `npm config set //registry.npmjs.org/:_authToken npm_XXXXXXXX`
 4. Verify: `npm whoami` → your user; `npm org ls allure-notifications` → you are owner/admin.
 5. `pnpm test` green on the release commit.
-6. Git tag `v6.0.0` (GitHub Release) on this line.
+6. Git tag `v6.0.x` (GitHub Release) on this line.
 
 ### Check before publish
 
@@ -50,25 +51,44 @@ If publish still returns E403: the token is a web-session token (no Bypass 2FA) 
 
 ## Publish
 
-From repo root (branch with 6.0.0 packages):
+From repo root (release branch with bumped `6.0.x` packages):
 
 ```bash
 pnpm install
 pnpm test
 pnpm run publish:packages
-# or, in dependency order:
-# pnpm --filter @allure-notifications/config publish --access public --no-git-checks
-# pnpm --filter @allure-notifications/pyramid publish --access public --no-git-checks
-# pnpm --filter @allure-notifications/core publish --access public --no-git-checks
-# pnpm --filter allure-notifications publish --access public --no-git-checks
 ```
 
-`pnpm` rewrites `workspace:*` → `6.0.0` in the published tarball.
+`publish:packages` already includes **plugin**. pnpm filter order (dependency → consumers):
+
+1. `@allure-notifications/config`
+2. `@allure-notifications/pyramid`
+3. `@allure-notifications/core`
+4. `allure-notifications` (CLI bin)
+5. `@allure-notifications/plugin`
+
+Equivalent manual sequence:
+
+```bash
+pnpm --filter @allure-notifications/config publish --access public --no-git-checks
+pnpm --filter @allure-notifications/pyramid publish --access public --no-git-checks
+pnpm --filter @allure-notifications/core publish --access public --no-git-checks
+pnpm --filter allure-notifications publish --access public --no-git-checks
+pnpm --filter @allure-notifications/plugin publish --access public --no-git-checks
+```
+
+`pnpm` rewrites `workspace:*` → the release version in the published tarball.
+
+**6.0.5 note:** first release that publishes `@allure-notifications/plugin` (CLI + scoped libs already on npm through 6.0.4). Do not publish plugin alone without the matching CLI/core cut.
 
 ## Consumer
 
 ```bash
-npx allure-notifications@6.0.0 send --config config.json --live
+# primary — CLI pin from docs/allure-notifications/VERSION
+npx allure-notifications@6.0.4 send --config config.json --live
+
+# alternate (after 6.0.5) — Allure 3 plugin via allurerc
+# see examples/allurerc.notifications.mjs
 ```
 
 Secrets unchanged (ADR 008): `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `TELEGRAM_TOPIC_ID`.

--- a/docs/telegram-dogfood.md
+++ b/docs/telegram-dogfood.md
@@ -1,7 +1,9 @@
 # Telegram dogfood (6.0 CLI · ADR 008)
 
-Live `sendPhoto` of a CB-870 collage via `@allure-notifications/cli`.  
+Live `sendPhoto` of a CB-870 collage via **`@allure-notifications/cli` (primary)**.  
 **Default CLI mode stays `--dry-run` / `--mock` (no network).** Live requires explicit `--live`.
+
+**Alternate:** Allure 3 plugin (`mode: "live"`) after `allure generate` — same credentials / ADR 008. Example: [`examples/allurerc.notifications.mjs`](../examples/allurerc.notifications.mjs) · [`packages/plugin/README.md`](../packages/plugin/README.md). Consumer CI keeps the CLI pin until npm **6.0.5** publishes the plugin.
 
 ## Canon (ADR 008)
 
@@ -65,9 +67,18 @@ node packages/cli/dist/src/bin.js send \
   - Forks: never `--live`.
   - Config prefers this run’s `allure-report/` / `allure-results/`; fallback dogfood CB-870.
 
+## Consumer pin checklist (after 6.0.5)
+
+Do **not** bump live pins in this docs-prep increment (`VERSION` stays **6.0.4**). After release **6.0.5**:
+
+1. Bump monorepo `docs/allure-notifications/VERSION` → `6.0.5`
+2. Sync agent file `/opt/qa-guru/etc/allure-notifications.version` (from VERSION)
+3. Ethalon / RAG hard-coded pins → `6.0.5` (where not reading VERSION)
+4. Optional: try plugin path via `allurerc` — CLI remains primary
+
 ## See also
 
 - ADR 008 · monorepo `docs/adr/008-allure-notifications-monitoring.md`
-- CI cookbook: [`ci-cookbook.md`](ci-cookbook.md) (§ Telegram Q4)
+- CI cookbook: [`ci-cookbook.md`](ci-cookbook.md) (§ Telegram Q4 · § Alternate plugin)
 - Hub plan: `projects/allure-notifications-home/PLAN-6.0.md`
 - Instance contour: monorepo `docs/allure-notifications/QUALITY-CONTOUR.md`

--- a/examples/allurerc.notifications.mjs
+++ b/examples/allurerc.notifications.mjs
@@ -1,11 +1,15 @@
 /**
  * Example allurerc — Allure 3 + @allure-notifications/plugin (Phase 5).
  *
- * Usage (after `pnpm add allure @allure-notifications/plugin`):
+ * Alternate to the CLI post-step (CLI pin stays primary for consumers):
+ *   npx allure-notifications send --config ./config/ci-telegram.json --dry-run
+ *
+ * Usage (after `pnpm add allure @allure-notifications/plugin`; npm public from 6.0.5):
  *   npx allure generate ./allure-results --config ./examples/allurerc.notifications.mjs
  *
  * Default mode is dry-run (collage + messenger plan, no network).
  * Set mode: "live" only with TELEGRAM_* credentials (ADR 008).
+ * Docs: packages/plugin/README.md · docs/ci-cookbook.md · docs/telegram-dogfood.md
  */
 import { defineConfig } from "allure";
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,6 +18,8 @@ npx allure-notifications send --config config.json --live   # Telegram ADR 008
 
 Default without `--mock` / `--live` is safe **dry-run**. Live credentials: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `TELEGRAM_TOPIC_ID` — see [`docs/telegram-dogfood.md`](../../docs/telegram-dogfood.md).
 
+**Alternate (Allure 3 plugin):** same collage + messengers via `allurerc` `done` hook — [`examples/allurerc.notifications.mjs`](../../examples/allurerc.notifications.mjs) · [`packages/plugin/README.md`](../plugin/README.md). CLI pin stays primary for consumers.
+
 Workspace (pre-publish / local):
 
 ```bash

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -2,16 +2,20 @@
 
 Allure 3 **plugin** for line **6.0.\*** — thin wrapper over `@allure-notifications/core` + CLI messengers.
 
-Etalon: [`@allurereport/plugin-slack`](https://github.com/allure-framework/allure3/blob/main/packages/plugin-slack/src/plugin.ts) `done` hook.
+Runs in the Allure 3 `done` hook (etalon: [`@allurereport/plugin-slack`](https://github.com/allure-framework/allure3/blob/main/packages/plugin-slack/src/plugin.ts)). Same collage + messenger pipeline as the CLI; **CLI remains the primary consumer path**.
 
 ## Install
 
 ```bash
-npm add @allure-notifications/plugin
+npm add allure @allure-notifications/plugin
 # workspace: already in pnpm packages/plugin
 ```
 
+> **npm status:** package lands on the public registry with release **6.0.5**. Until then use the workspace / git dependency, or keep the CLI pin (`npx allure-notifications@6.0.4`).
+
 ## allurerc
+
+Full copy-paste example: [`examples/allurerc.notifications.mjs`](../../examples/allurerc.notifications.mjs).
 
 ```js
 import { defineConfig } from "allure";
@@ -24,28 +28,57 @@ export default defineConfig({
     notifications: {
       import: "@allure-notifications/plugin",
       options: {
+        // Same JSON schema as: npx allure-notifications send --config …
         config: "./config/notifications.json",
         mode: "dry-run", // "dry-run" | "mock" | "live" — default dry-run
+        // out: "./collage.png",
       },
     },
   },
 });
 ```
 
-Full example: [`examples/allurerc.notifications.mjs`](../../examples/allurerc.notifications.mjs).
+```bash
+npx allure generate ./allure-results --config ./examples/allurerc.notifications.mjs
+```
+
+The plugin fires **after** report generation (`done`). Point `options.config` at the same `config.json` the CLI would use.
 
 ## Options
 
 | Option | Type | Default | Role |
 |--------|------|---------|------|
-| `config` | `string \| object` | **required** | Path to `config.json` or inline CLI schema |
-| `mode` | `"dry-run" \| "mock" \| "live"` | `dry-run` | Messengers; live = Telegram ADR 008 |
+| `config` | `string \| object` | **required** | Path to `config.json` (cwd-relative) or inline object — **same schema as CLI** `send --config` |
+| `mode` | `"dry-run" \| "mock" \| "live"` | `dry-run` | Messenger delivery mode (see below) |
 | `out` | `string` | — | Write collage PNG to disk |
-| `allureFolder` | `string` | `context.output` if unset in config | Report dir for summary |
+| `allureFolder` | `string` | `context.output` if unset in config | Report dir for `summary.json` |
 | `allureResultsFolder` | `string` | from config | Results for analytics |
-| `reportFile` | `string \| false` | `allure-notifications-collage.png` | Attach PNG into report; `false` to skip |
+| `reportFile` | `string \| false` | `allure-notifications-collage.png` | Attach PNG into the report; `false` to skip |
 
 Pipeline in `done`: `parseConfig` → `loadReportAnalytics` / `renderCollagePng` (core, `@napi-rs/canvas`) → `deliver` (CLI messengers). **No network** unless `mode: "live"`.
+
+## dry-run vs live (and CLI)
+
+| Path | Safe default | Live Telegram |
+|------|--------------|---------------|
+| **CLI (primary)** | `npx allure-notifications send --config … --dry-run` | explicit `--live` + `TELEGRAM_*` |
+| **Plugin (alternate)** | `mode: "dry-run"` (default) | `mode: "live"` + same env |
+
+| `mode` | Behavior |
+|--------|----------|
+| `dry-run` | Render PNG; list messengers that *would* send; **no network** |
+| `mock` | Render PNG; record mock deliveries; **no network** |
+| `live` | Live Telegram `sendPhoto` (ADR 008); needs `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` / `TELEGRAM_TOPIC_ID` |
+
+Equivalent CLI:
+
+```bash
+# after allure generate (no plugin)
+npx allure-notifications send --config ./config/notifications.json --dry-run
+npx allure-notifications send --config ./config/notifications.json --live
+```
+
+Dogfood / credentials: [`docs/telegram-dogfood.md`](../../docs/telegram-dogfood.md). CI cookbook: [`docs/ci-cookbook.md`](../../docs/ci-cookbook.md).
 
 ## Verify
 


### PR DESCRIPTION
## Summary
- Polish `@allure-notifications/plugin` README (allurerc, options, dry-run vs live, CLI link)
- Keep `examples/allurerc.notifications.mjs` current; link from root README / MIGRATION / cookbook
- Document `publish:packages` order including plugin in `docs/npm-publish.md`
- CI cookbook + telegram-dogfood: CLI pin primary; plugin = alternate after `allure generate`
- Consumer pin checklist «после 6.0.5» only — no VERSION bump, no npm publish

## Test plan
- [ ] Skim plugin README + example against Phase 5 options
- [ ] Confirm `pnpm run publish:packages` filter list matches npm-publish.md order
- [ ] `VERSION` / package.json still **6.0.4** (no publish in this PR)

Made with [Cursor](https://cursor.com)