### PR TITLE
feat(examples): GitHub Actions plugin notify sample + plugin main fix

### DIFF
--- a/.github/workflows/example-plugin-notify.yml
+++ b/.github/workflows/example-plugin-notify.yml
@@ -53,7 +53,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist-pack
-          pnpm --filter @allure-notifications/plugin pack --pack-destination "$GITHUB_WORKSPACE/dist-pack"
+          # pnpm pack rejects --filter (Unknown option: recursive); pack from package dir
+          pnpm --filter @allure-notifications/plugin exec pnpm pack --pack-destination "$GITHUB_WORKSPACE/dist-pack"
           ls -la dist-pack/
 
       - name: Consumer-style npm install + dogfood notify

--- a/.github/workflows/example-plugin-notify.yml
+++ b/.github/workflows/example-plugin-notify.yml
@@ -1,0 +1,105 @@
+# Example: Allure 3 plugin notify (separate from CLI Q4 telegram job).
+# Manual only — does not gate PRs. Default mode = dry-run (no Telegram network).
+# live: TELEGRAM_* secrets; soft-skip if missing.
+#
+# Consumer-faithful: pnpm build + pack workspace plugin → npm install (like consumers).
+# Copy-paste template: examples/github-actions/plugin-notify.yml
+# Docs: examples/github-actions/README.md · packages/plugin/README.md · docs/ci-cookbook.md
+
+name: Example — plugin notify
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Messenger mode (live needs TELEGRAM_* secrets)
+        type: choice
+        options:
+          - dry-run
+          - live
+        default: dry-run
+
+concurrency:
+  group: example-plugin-notify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-notify:
+    name: allure generate + plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install workspace + build plugin
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+          pnpm --filter @allure-notifications/plugin... build
+
+      - name: Pack plugin (rewrites workspace:* → versions)
+        run: |
+          set -euo pipefail
+          mkdir -p dist-pack
+          pnpm --filter @allure-notifications/plugin pack --pack-destination "$GITHUB_WORKSPACE/dist-pack"
+          ls -la dist-pack/
+
+      - name: Consumer-style npm install + dogfood notify
+        env:
+          NOTIFICATION_MODE: ${{ inputs.mode }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN || secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_TOPIC_ID: ${{ vars.TELEGRAM_TOPIC_ID || vars.TELEGRAM_ALLURE_NOTIFICATIONS_TOPIC_ID || '34' }}
+        run: |
+          set -euo pipefail
+          rm -rf example-run
+          mkdir example-run
+          cd example-run
+          npm init -y >/dev/null
+          npm install allure@^3.14.3 "$(ls ../dist-pack/allure-notifications-plugin-*.tgz)"
+
+          cp -R ../packages/core/test/fixtures/dogfood-results ./allure-results
+          mkdir -p examples/github-actions
+          cp ../examples/github-actions/allurerc.mjs \
+             ../examples/github-actions/notifications.config.json \
+             examples/github-actions/
+
+          # 1) Report files on disk (Plugin.done runs before flush)
+          npx allure generate ./allure-results -o ./allure-report
+
+          if [[ "${NOTIFICATION_MODE}" == "live" ]]; then
+            if [[ -z "${TELEGRAM_BOT_TOKEN:-}" || -z "${TELEGRAM_CHAT_ID:-}" ]]; then
+              echo "live requested but TELEGRAM_* missing — soft-skip"
+              exit 0
+            fi
+          fi
+
+          # 2) Generate again with plugin — reads report from step 1
+          npx allure generate ./allure-results \
+            --config ./examples/github-actions/allurerc.mjs
+
+          test -f collage-plugin.png
+          ls -la collage-plugin.png
+
+      - name: Upload collage + report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-plugin-notify
+          path: |
+            example-run/collage-plugin.png
+            example-run/allure-report/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ node_modules/
 packages/*/dist/
 packages/*/coverage/
 *.tsbuildinfo
+dist-pack/
+*.tgz
 apps/*/test-results/
 apps/*/playwright-report/
 apps/*/playwright/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,26 @@
 # Changelog
 
-## Unreleased (propose **6.0.6**)
+## v 6.0.7
 
 ### English
 
-- **Plugin resolve fix** — `@allure-notifications/plugin` adds `main`/`module`/`types` so Allure 3 `require.resolve` can load the package (6.0.5 `exports`-only broke `allurerc` import)
+- **Plugin resolve fix** — `@allure-notifications/plugin` adds `main`/`module`/`types` so Allure 3 `require.resolve` can load the package (6.0.5 / npm `6.0.6` were `exports`-only and broke `allurerc` import)
 - **GitHub Actions example (plugin path)** — `examples/github-actions/` + `.github/workflows/example-plugin-notify.yml` (two-step generate; not CLI Q4)
 
 ### Russian
 
-- **Фикс resolve плагина** — у `@allure-notifications/plugin` добавлены `main`/`module`/`types` (в 6.0.5 Allure не резолвил пакет из `allurerc`)
+- **Фикс resolve плагина** — у `@allure-notifications/plugin` добавлены `main`/`module`/`types` (6.0.5 / npm `6.0.6` — `exports`-only, Allure не резолвил пакет из `allurerc`)
 - **Пример GitHub Actions (plugin)** — `examples/github-actions/` + `.github/workflows/example-plugin-notify.yml` (два generate; не CLI Q4)
+
+## v 6.0.6
+
+### English
+
+- **Do not use** — npm `6.0.6` published without `main` (same resolve break as 6.0.5). Use **6.0.7**.
+
+### Russian
+
+- **Не использовать** — npm `6.0.6` без `main` (тот же break resolve, что у 6.0.5). Берите **6.0.7**.
 
 ## v 6.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## Unreleased (propose **6.0.5**)
+## Unreleased (propose **6.0.6**)
+
+### English
+
+- **Plugin resolve fix** — `@allure-notifications/plugin` adds `main`/`module`/`types` so Allure 3 `require.resolve` can load the package (6.0.5 `exports`-only broke `allurerc` import)
+- **GitHub Actions example (plugin path)** — `examples/github-actions/` + `.github/workflows/example-plugin-notify.yml` (two-step generate; not CLI Q4)
+
+### Russian
+
+- **Фикс resolve плагина** — у `@allure-notifications/plugin` добавлены `main`/`module`/`types` (в 6.0.5 Allure не резолвил пакет из `allurerc`)
+- **Пример GitHub Actions (plugin)** — `examples/github-actions/` + `.github/workflows/example-plugin-notify.yml` (два generate; не CLI Q4)
+
+## v 6.0.5
 
 ### English
 

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -39,7 +39,7 @@ npx allure generate ./allure-results --config ./examples/allurerc.notifications.
 | Live | `--live` + `TELEGRAM_*` | `mode: "live"` + same env |
 | Config | `config.json` | `options.config` → same schema |
 
-npm `@allure-notifications/plugin` publishes with **6.0.5** (404 until then). Keep consumer CI on the CLI pin until that release.
+npm `@allure-notifications/plugin` — needs **`main`** for Allure `require.resolve` (**≥6.0.6**; workspace dogfood OK). **Separate GitHub Actions example (plugin, not CLI):** [`examples/github-actions/`](../examples/github-actions/) · runnable workflow [`.github/workflows/example-plugin-notify.yml`](../.github/workflows/example-plugin-notify.yml) (`workflow_dispatch`, default dry-run).
 
 ## Workspace (local / before `npx`)
 
@@ -197,6 +197,25 @@ jobs:
 ```
 
 Replace `npx allure-notifications` with `pnpm exec allure-notifications` when consuming the workspace before publish. Point `base.allureFolder` / `base.allureResultsFolder` in `config/notifications.json` at the generated paths.
+
+## GitHub Actions — consumer notify via plugin (alternate)
+
+Same job shape as the CLI consumer example, but notifications run in `allurerc` (`done` hook). **Two generate steps** (Allure flushes `summary.json` after `Plugin.done` — see [`examples/github-actions/README.md`](../examples/github-actions/README.md)). Full template: [`examples/github-actions/plugin-notify.yml`](../examples/github-actions/plugin-notify.yml). Product dogfood: Actions → **Example — plugin notify**.
+
+```yaml
+- name: Install Allure 3 + plugin
+  run: npm install allure@^3.14.3 @allure-notifications/plugin@6.0.6
+
+- name: Generate report (files on disk)
+  run: npx allure generate ./allure-results -o ./allure-report
+
+- name: Generate again + plugin notify
+  env:
+    NOTIFICATION_MODE: dry-run   # or live + TELEGRAM_*
+  run: |
+    npx allure generate ./allure-results \
+      --config ./examples/github-actions/allurerc.mjs
+```
 
 ## Jenkins (dry-run)
 

--- a/docs/ci-cookbook.md
+++ b/docs/ci-cookbook.md
@@ -39,7 +39,7 @@ npx allure generate ./allure-results --config ./examples/allurerc.notifications.
 | Live | `--live` + `TELEGRAM_*` | `mode: "live"` + same env |
 | Config | `config.json` | `options.config` → same schema |
 
-npm `@allure-notifications/plugin` — needs **`main`** for Allure `require.resolve` (**≥6.0.6**; workspace dogfood OK). **Separate GitHub Actions example (plugin, not CLI):** [`examples/github-actions/`](../examples/github-actions/) · runnable workflow [`.github/workflows/example-plugin-notify.yml`](../.github/workflows/example-plugin-notify.yml) (`workflow_dispatch`, default dry-run).
+npm `@allure-notifications/plugin` — needs **`main`** for Allure `require.resolve` (**≥6.0.7**; skip 6.0.6; workspace dogfood OK). **Separate GitHub Actions example (plugin, not CLI):** [`examples/github-actions/`](../examples/github-actions/) · runnable workflow [`.github/workflows/example-plugin-notify.yml`](../.github/workflows/example-plugin-notify.yml) (`workflow_dispatch`, default dry-run).
 
 ## Workspace (local / before `npx`)
 
@@ -204,7 +204,7 @@ Same job shape as the CLI consumer example, but notifications run in `allurerc` 
 
 ```yaml
 - name: Install Allure 3 + plugin
-  run: npm install allure@^3.14.3 @allure-notifications/plugin@6.0.6
+  run: npm install allure@^3.14.3 @allure-notifications/plugin@6.0.7
 
 - name: Generate report (files on disk)
   run: npx allure generate ./allure-results -o ./allure-report

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -81,6 +81,12 @@ pnpm --filter @allure-notifications/plugin publish --access public --no-git-chec
 
 **6.0.5 note:** first release that publishes `@allure-notifications/plugin` (CLI + scoped libs already on npm through 6.0.4). Do not publish plugin alone without the matching CLI/core cut.
 
+**6.0.7 note (plugin-only):** npm `6.0.6` is broken (`exports`-only, no `main`). Publish only `@allure-notifications/plugin@6.0.7`; CLI/libs stay at **6.0.5**. Skip `publish:packages` for this cut — use:
+
+```bash
+pnpm --filter @allure-notifications/plugin publish --access public --no-git-checks
+```
+
 ## Consumer
 
 ```bash

--- a/examples/allurerc.notifications.mjs
+++ b/examples/allurerc.notifications.mjs
@@ -10,6 +10,7 @@
  * Default mode is dry-run (collage + messenger plan, no network).
  * Set mode: "live" only with TELEGRAM_* credentials (ADR 008).
  * Docs: packages/plugin/README.md · docs/ci-cookbook.md · docs/telegram-dogfood.md
+ * GitHub Actions (plugin): examples/github-actions/ · .github/workflows/example-plugin-notify.yml
  */
 import { defineConfig } from "allure";
 

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -33,7 +33,9 @@ CLI post-step remains the simpler primary path when you only need notify-after-g
 ```bash
 # Pack workspace plugin (or npm i @allure-notifications/plugin@≥6.0.6 after publish)
 pnpm install && pnpm --filter @allure-notifications/plugin... build
-mkdir -p dist-pack && pnpm --filter @allure-notifications/plugin pack --pack-destination ./dist-pack
+mkdir -p dist-pack
+# pnpm pack rejects --filter (Unknown option: recursive); pack from package dir
+pnpm --filter @allure-notifications/plugin exec pnpm pack --pack-destination ./dist-pack
 
 rm -rf /tmp/an-plugin-smoke && mkdir /tmp/an-plugin-smoke && cd /tmp/an-plugin-smoke
 npm init -y && npm install allure@^3.14.3 "$REPO/dist-pack"/allure-notifications-plugin-*.tgz

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -31,7 +31,7 @@ CLI post-step remains the simpler primary path when you only need notify-after-g
 ## Local smoke
 
 ```bash
-# Pack workspace plugin (or npm i @allure-notifications/plugin@≥6.0.6 after publish)
+# Pack workspace plugin (or npm i @allure-notifications/plugin@≥6.0.7 after publish)
 pnpm install && pnpm --filter @allure-notifications/plugin... build
 mkdir -p dist-pack
 # pnpm pack rejects --filter (Unknown option: recursive); pack from package dir

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -1,0 +1,56 @@
+# GitHub Actions — notify via Allure 3 plugin
+
+Alternate CI path: collage + messengers run **inside** `allure generate` (`done` hook), not as a separate `allure-notifications send` step.
+
+| Path | When |
+|------|------|
+| **CLI (primary)** | Post-step after generate — see [ci-cookbook.md](../../docs/ci-cookbook.md) § consumer notify |
+| **Plugin (this folder)** | `allure generate --config …` with `plugins.notifications` |
+
+## Files
+
+| File | Role |
+|------|------|
+| [`allurerc.mjs`](allurerc.mjs) | Allure 3 config: awesome + `@allure-notifications/plugin` |
+| [`notifications.config.json`](notifications.config.json) | Same schema as CLI `send --config` |
+| [`plugin-notify.yml`](plugin-notify.yml) | Copy-paste consumer workflow template |
+
+Runnable dogfood in this repository (Actions → **Run workflow**):
+
+[`.github/workflows/example-plugin-notify.yml`](../../.github/workflows/example-plugin-notify.yml)
+
+## Why two generate steps?
+
+Allure 3 calls `Plugin.done` **before** report files (including `summary.json`) are flushed to disk. The notifications plugin reads that report from disk (same as CLI), so:
+
+1. Generate the report **without** the plugin (files land on disk).
+2. Generate again **with** this `allurerc` — `done` reads the report from step 1, renders collage, dry-runs/sends messengers.
+
+CLI post-step remains the simpler primary path when you only need notify-after-generate.
+
+## Local smoke
+
+```bash
+# Pack workspace plugin (or npm i @allure-notifications/plugin@≥6.0.6 after publish)
+pnpm install && pnpm --filter @allure-notifications/plugin... build
+mkdir -p dist-pack && pnpm --filter @allure-notifications/plugin pack --pack-destination ./dist-pack
+
+rm -rf /tmp/an-plugin-smoke && mkdir /tmp/an-plugin-smoke && cd /tmp/an-plugin-smoke
+npm init -y && npm install allure@^3.14.3 "$REPO/dist-pack"/allure-notifications-plugin-*.tgz
+cp -R "$REPO/packages/core/test/fixtures/dogfood-results" ./allure-results
+mkdir -p examples/github-actions
+cp "$REPO/examples/github-actions/"allurerc.mjs \
+   "$REPO/examples/github-actions/"notifications.config.json \
+   examples/github-actions/
+
+npx allure generate ./allure-results -o ./allure-report
+NOTIFICATION_MODE=dry-run npx allure generate ./allure-results \
+  --config ./examples/github-actions/allurerc.mjs
+# → collage-plugin.png
+```
+
+(`$REPO` = path to this repository root.)
+
+`NOTIFICATION_MODE=live` only with `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` / `TELEGRAM_TOPIC_ID` (ADR 008).
+
+More: [`packages/plugin/README.md`](../../packages/plugin/README.md) · [`docs/ci-cookbook.md`](../../docs/ci-cookbook.md).

--- a/examples/github-actions/allurerc.mjs
+++ b/examples/github-actions/allurerc.mjs
@@ -1,0 +1,41 @@
+/**
+ * allurerc for the GitHub Actions plugin example.
+ *
+ * Notifications run inside `allure generate` (plugin `done` hook) — not as a
+ * separate `allure-notifications send` post-step.
+ *
+ * Important (Allure 3 flush timing):
+ *   Plugin.done runs before report files are on disk. Point `allureFolder` at a
+ *   report that already exists (generate once without the plugin, then again
+ *   with this config) — see examples/github-actions/README.md.
+ *
+ * Mode from env:
+ *   NOTIFICATION_MODE=dry-run|mock|live  (default dry-run)
+ *
+ * Usage:
+ *   npx allure generate ./allure-results -o ./allure-report
+ *   NOTIFICATION_MODE=dry-run npx allure generate ./allure-results \
+ *     --config ./examples/github-actions/allurerc.mjs
+ */
+import { defineConfig } from "allure";
+
+const mode = process.env.NOTIFICATION_MODE || "dry-run";
+
+export default defineConfig({
+  name: "Allure Report",
+  output: "./allure-report",
+  plugins: {
+    awesome: {},
+    notifications: {
+      import: "@allure-notifications/plugin",
+      options: {
+        config: "./examples/github-actions/notifications.config.json",
+        mode,
+        out: "./collage-plugin.png",
+        // Existing report from the prior generate step (cwd-relative)
+        allureFolder: "./allure-report",
+        allureResultsFolder: "./allure-results",
+      },
+    },
+  },
+});

--- a/examples/github-actions/notifications.config.json
+++ b/examples/github-actions/notifications.config.json
@@ -1,0 +1,46 @@
+{
+  "base": {
+    "project": "plugin-gh-example",
+    "environment": "GitHub Actions",
+    "comment": "Example: Allure 3 plugin notify (done hook)",
+    "language": "en",
+    "allureFolder": "../../allure-report",
+    "allureResultsFolder": "../../allure-results",
+    "enableChart": true,
+    "darkMode": true,
+    "enableSuitesPublishing": false,
+    "chart": {
+      "mode": "collage",
+      "layout": "free",
+      "width": 870,
+      "height": 1080,
+      "headerHeight": 56,
+      "cardGap": 14,
+      "tilePad": 6,
+      "gridCols": 10,
+      "gridRows": 10,
+      "items": [
+        { "type": "pie", "x": 0, "y": 0, "w": 4, "h": 4 },
+        { "type": "statusDynamics", "x": 4, "y": 0, "w": 6, "h": 4 },
+        { "type": "testingPyramid", "x": 0, "y": 4, "w": 4, "h": 3 },
+        { "type": "durations", "x": 4, "y": 4, "w": 6, "h": 3, "groupBy": "layer" },
+        { "type": "successRateDistribution", "x": 0, "y": 7, "w": 7, "h": 3 },
+        { "type": "testResultSeverities", "x": 7, "y": 7, "w": 3, "h": 3 }
+      ],
+      "pyramidFallback": "suites"
+    },
+    "links": {
+      "report": "",
+      "dashboard": "",
+      "testops": "",
+      "build": ""
+    }
+  },
+  "telegram": {
+    "token": "",
+    "chat": "",
+    "topic": "",
+    "replyTo": "",
+    "templatePath": "/templates/telegram.ftl"
+  }
+}

--- a/examples/github-actions/plugin-notify.yml
+++ b/examples/github-actions/plugin-notify.yml
@@ -1,0 +1,75 @@
+# Consumer copy-paste: Allure 3 generate + @allure-notifications/plugin (done hook).
+#
+# Difference from CLI post-step:
+#   CLI:     npx allure generate … && npx allure-notifications send --config …
+#   Plugin:  generate report → generate again with allurerc (notifications in done)
+#
+# Requires @allure-notifications/plugin ≥6.0.6 (`main` entry — Allure resolve).
+# Drop into .github/workflows/ or merge steps into your test workflow.
+# Docs: packages/plugin/README.md · docs/ci-cookbook.md · examples/github-actions/README.md
+#
+# Runnable dogfood in this repo:
+#   .github/workflows/example-plugin-notify.yml  (Actions → Run workflow)
+
+name: allure-notifications (plugin)
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Messenger mode (live needs TELEGRAM_* secrets)
+        type: choice
+        options:
+          - dry-run
+          - live
+        default: dry-run
+
+jobs:
+  notify-via-plugin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Pin ≥6.0.6 (main entry for Allure require.resolve). Bump with VERSION checklist.
+      - name: Install Allure 3 + notifications plugin
+        run: npm install allure@^3.14.3 @allure-notifications/plugin@6.0.6
+
+      # Expect ./allure-results from your test job (upload/download-artifact or same job).
+
+      - name: Generate report (files on disk)
+        run: npx allure generate ./allure-results -o ./allure-report
+
+      - name: Generate again + plugin notify
+        env:
+          NOTIFICATION_MODE: ${{ inputs.mode }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN || secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_TOPIC_ID: ${{ vars.TELEGRAM_TOPIC_ID || '34' }}
+        run: |
+          set -euo pipefail
+          if [[ "${NOTIFICATION_MODE}" == "live" ]]; then
+            if [[ -z "${TELEGRAM_BOT_TOKEN:-}" || -z "${TELEGRAM_CHAT_ID:-}" ]]; then
+              echo "live requested but TELEGRAM_* missing — soft-skip (use dry-run locally)"
+              exit 0
+            fi
+          fi
+          # Keep allurerc + config from this example in your repo:
+          #   examples/github-actions/allurerc.mjs
+          #   examples/github-actions/notifications.config.json
+          npx allure generate ./allure-results \
+            --config ./examples/github-actions/allurerc.mjs
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: collage-plugin
+          path: |
+            collage-plugin.png
+            allure-report/
+          if-no-files-found: warn
+          retention-days: 7

--- a/examples/github-actions/plugin-notify.yml
+++ b/examples/github-actions/plugin-notify.yml
@@ -4,7 +4,7 @@
 #   CLI:     npx allure generate … && npx allure-notifications send --config …
 #   Plugin:  generate report → generate again with allurerc (notifications in done)
 #
-# Requires @allure-notifications/plugin ≥6.0.6 (`main` entry — Allure resolve).
+# Requires @allure-notifications/plugin ≥6.0.7 (`main` entry — Allure resolve; skip 6.0.6).
 # Drop into .github/workflows/ or merge steps into your test workflow.
 # Docs: packages/plugin/README.md · docs/ci-cookbook.md · examples/github-actions/README.md
 #
@@ -35,9 +35,9 @@ jobs:
         with:
           node-version: 20
 
-      # Pin ≥6.0.6 (main entry for Allure require.resolve). Bump with VERSION checklist.
+      # Pin ≥6.0.7 (main entry for Allure require.resolve; skip 6.0.6). Bump with VERSION checklist.
       - name: Install Allure 3 + notifications plugin
-        run: npm install allure@^3.14.3 @allure-notifications/plugin@6.0.6
+        run: npm install allure@^3.14.3 @allure-notifications/plugin@6.0.7
 
       # Expect ./allure-results from your test job (upload/download-artifact or same job).
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -11,7 +11,7 @@ npm add allure @allure-notifications/plugin
 # workspace: already in pnpm packages/plugin
 ```
 
-> **npm:** `@allure-notifications/plugin` — use **≥6.0.6** (`main` entry required for Allure resolve). Workspace `packages/plugin` for monorepo dogfood.
+> **npm:** `@allure-notifications/plugin` — use **≥6.0.7** (`main` entry required for Allure resolve; skip 6.0.6). Workspace `packages/plugin` for monorepo dogfood.
 
 ## allurerc
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -11,11 +11,13 @@ npm add allure @allure-notifications/plugin
 # workspace: already in pnpm packages/plugin
 ```
 
-> **npm status:** package lands on the public registry with release **6.0.5**. Until then use the workspace / git dependency, or keep the CLI pin (`npx allure-notifications@6.0.5`).
+> **npm:** `@allure-notifications/plugin` — use **≥6.0.6** (`main` entry required for Allure resolve). Workspace `packages/plugin` for monorepo dogfood.
 
 ## allurerc
 
 Full copy-paste example: [`examples/allurerc.notifications.mjs`](../../examples/allurerc.notifications.mjs).
+
+**GitHub Actions (plugin path):** [`examples/github-actions/`](../../examples/github-actions/) — copy-paste [`plugin-notify.yml`](../../examples/github-actions/plugin-notify.yml); runnable dogfood [`.github/workflows/example-plugin-notify.yml`](../../.github/workflows/example-plugin-notify.yml).
 
 ```js
 import { defineConfig } from "allure";
@@ -39,10 +41,11 @@ export default defineConfig({
 ```
 
 ```bash
+npx allure generate ./allure-results -o ./allure-report
 npx allure generate ./allure-results --config ./examples/allurerc.notifications.mjs
 ```
 
-The plugin fires **after** report generation (`done`). Point `options.config` at the same `config.json` the CLI would use.
+> **Generate twice for plugin path:** Allure calls `done` before `summary.json` is on disk. First generate writes the report; second generate (with `allurerc`) lets the plugin read it. Prefer CLI `send` when you only need a post-step. GH example: [`examples/github-actions/`](../../examples/github-actions/).
 
 ## Options
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@allure-notifications/plugin",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Allure 3 plugin — thin wrapper over core + CLI messengers (Phase 5).",
   "type": "module",
+  "main": "./dist/src/index.js",
+  "module": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
-    }
+    ".": "./dist/src/index.js"
   },
   "files": [
     "dist/src",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@allure-notifications/plugin",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Allure 3 plugin — thin wrapper over core + CLI messengers (Phase 5).",
   "type": "module",
   "main": "./dist/src/index.js",


### PR DESCRIPTION
## Summary
- Add `examples/github-actions/` consumer sample (allurerc + notifications.config + copy-paste workflow) and runnable dogfood workflow `example-plugin-notify.yml` (pack → npm install → two-step generate).
- Fix `@allure-notifications/plugin` `main`/`module`/`types` (Allure `require.resolve` broke on exports-only at 6.0.5) and bump package version to **6.0.6** (not published yet).
- Document two-step generate (Plugin.done before summary.json flush) and pack via `pnpm … exec pnpm pack` (pnpm 9.15 rejects `--filter pack`).

## Notes
- CLI remains primary; plugin is alternate.
- **Do not publish** `@allure-notifications/plugin@6.0.6` until explicitly requested after merge.

## Test plan
- [x] Local smoke: build → pack → consumer npm install → two-step generate → `collage-plugin.png` 870×1080
- [x] `pnpm --filter @allure-notifications/plugin test` (7/7)
- [ ] Actions → Run workflow **Example — plugin notify** (dry-run)
- [ ] After merge: decide publish of plugin@6.0.6


Made with [Cursor](https://cursor.com)