### PR TITLE
fix(examples): absolute dist-pack path in plugin GH Actions smoke README

### DIFF
--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -32,10 +32,13 @@ CLI post-step remains the simpler primary path when you only need notify-after-g
 
 ```bash
 # Pack workspace plugin (or npm i @allure-notifications/plugin@≥6.0.7 after publish)
+# $REPO = path to this repository root
+cd "$REPO"
 pnpm install && pnpm --filter @allure-notifications/plugin... build
 mkdir -p dist-pack
-# pnpm pack rejects --filter (Unknown option: recursive); pack from package dir
-pnpm --filter @allure-notifications/plugin exec pnpm pack --pack-destination ./dist-pack
+# pnpm pack rejects --filter (Unknown option: recursive); pack from package dir.
+# Use absolute pack-destination — exec cwd is packages/plugin, so ./dist-pack would land there.
+pnpm --filter @allure-notifications/plugin exec pnpm pack --pack-destination "$REPO/dist-pack"
 
 rm -rf /tmp/an-plugin-smoke && mkdir /tmp/an-plugin-smoke && cd /tmp/an-plugin-smoke
 npm init -y && npm install allure@^3.14.3 "$REPO/dist-pack"/allure-notifications-plugin-*.tgz
@@ -48,10 +51,8 @@ cp "$REPO/examples/github-actions/"allurerc.mjs \
 npx allure generate ./allure-results -o ./allure-report
 NOTIFICATION_MODE=dry-run npx allure generate ./allure-results \
   --config ./examples/github-actions/allurerc.mjs
-# → collage-plugin.png
+# → collage-plugin.png (870×1080)
 ```
-
-(`$REPO` = path to this repository root.)
 
 `NOTIFICATION_MODE=live` only with `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` / `TELEGRAM_TOPIC_ID` (ADR 008).
 


### PR DESCRIPTION
## Summary
- Align local smoke pack path with the runnable workflow (`$REPO/dist-pack` / `$GITHUB_WORKSPACE/dist-pack`).
- `pnpm --filter … exec` cwd is `packages/plugin`, so relative `./dist-pack` left the tarball outside `$REPO/dist-pack` and broke the documented `npm install`.

## Verification
- Local two-step plugin smoke: `collage-plugin.png` 870×1080 PNG
- `pnpm --filter @allure-notifications/plugin test` — 7/7 pass

## Notes
- Main sample already merged in #492 (`main`/`module`/`types` + example workflow).
- No npm publish / no 6.0.6 release in this PR.

## Test plan
- [ ] Follow `examples/github-actions/README.md` Local smoke from a clean shell
- [ ] Confirm tarball lands in `$REPO/dist-pack/`
- [ ] Optional: Actions → **Example — plugin notify** workflow_dispatch dry-run


Made with [Cursor](https://cursor.com)