### PR TITLE
fix(docs): restore root README on GitHub repo homepage

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,34 +7,34 @@ no Telegram network call is required.
 ## Variants
 
 1. **Marketplace Action — recommended**
-   - Workflow: [`example-marketplace.yml`](workflows/example-marketplace.yml)
+   - Workflow: [`example-marketplace.yml`](example-marketplace.yml)
    - Runtime: `qa-guru/allure-notifications@v6`
    - Pipeline: install Allure → one report generate → Action send.
 
 2. **Native npm CLI**
-   - Workflow: [`example-native-cli.yml`](workflows/example-native-cli.yml)
+   - Workflow: [`example-native-cli.yml`](example-native-cli.yml)
    - Runtime: `@qa-guru/allure-notifications@6.0.14`
    - Pipeline: install published packages → one report generate → CLI `send`.
 
 3. **Allure plugin — alternate capability**
-   - Workflow: [`example-allure-plugin.yml`](workflows/example-allure-plugin.yml)
+   - Workflow: [`example-allure-plugin.yml`](example-allure-plugin.yml)
    - Runtime: `@qa-guru/allure-notifications-plugin@6.0.14`
    - The plugin executes in `Plugin.done`. The dogfood example supplies a
      checked-in report fixture because files from the current generate are
      flushed after `done`.
 
 4. **Local Action source — repository E2E**
-   - Workflow: [`action-e2e.yml`](workflows/action-e2e.yml)
+   - Workflow: [`action-e2e.yml`](action-e2e.yml)
    - Runtime: root `action.yml` through `uses: ./`.
    - Runs on pushes and pull requests as the release gate.
 
 5. **Legacy Java JAR**
-   - Workflow: [`build.yml`](workflows/build.yml)
+   - Workflow: [`build.yml`](build.yml)
    - Kept for the frozen Java 5.0.8 capability; it is not the recommended 6.x
      consumer path.
 
 All runnable examples validate the collage with the local
-[`assert-collage`](actions/assert-collage/action.yml) composite Action and
+[`assert-collage`](../actions/assert-collage/action.yml) composite Action and
 upload the PNG/report as workflow artifacts.
 
 ## Run manually
@@ -50,6 +50,6 @@ Use `mode=live` only when `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and
 are never rendered into JSON.
 
 Shared report configs live in
-[`examples/allure-notifications/`](examples/allure-notifications/). The static
+[`examples/allure-notifications/`](../../examples/allure-notifications/). The static
 notification config reused by the examples is
-[`examples/github-actions/notifications/config.json`](../examples/github-actions/notifications/config.json).
+[`examples/github-actions/notifications/config.json`](../../examples/github-actions/notifications/config.json).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Pipeline: `tests → allure-results → npx allure generate (once) → Action se
 The Action never generates the report and never writes credentials to JSON.
 See the [complete workflow and static config](examples/github-actions/).
 Runnable Marketplace, native CLI, plugin, and local-Action variants live in
-[`.github/README.md`](.github/README.md).
+[`.github/workflows/README.md`](.github/workflows/README.md).
 
 ## Notification example
 

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -1,7 +1,7 @@
 # GitHub Marketplace Action
 
 Runnable dogfood workflows for every integration variant are documented in
-[`.github/README.md`](../../.github/README.md).
+[`.github/workflows/README.md`](../../.github/workflows/README.md).
 
 The primary pipeline is:
 


### PR DESCRIPTION
## Summary

- Move GHA dogfood docs from `.github/README.md` to `.github/workflows/README.md`.
- GitHub renders `.github/README.md` with higher priority than the root `README.md`, so the repo homepage accidentally showed workflow examples instead of the product landing.
- Update links in root `README.md` and `examples/github-actions/README.md`; fix relative paths inside the moved doc.

## Test plan

- [ ] Merge and confirm https://github.com/qa-guru/allure-notifications shows the root README (Allure notifications, omni-tool, ANB).
- [ ] Confirm `.github/workflows/README.md` still renders GHA examples with working relative links.


Made with [Cursor](https://cursor.com)