### PR TITLE
ci(legacy-java): stop running Java 5.0.8 CI on every push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,21 @@
-name: CI
+name: CI — legacy Java 5.0.8
 
 on:
+  workflow_dispatch:
   push:
     branches:
-    - master
+      - master
+    paths:
+      - 'legacy/java/**'
+      - 'config/ci-telegram.json'
+      - '.github/workflows/build.yml'
   pull_request:
     branches:
-    - master
+      - master
+    paths:
+      - 'legacy/java/**'
+      - 'config/ci-telegram.json'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:

--- a/.github/workflows/ci-6.0.yml
+++ b/.github/workflows/ci-6.0.yml
@@ -1,5 +1,5 @@
 # 6.0 TypeScript monorepo CI (master + feature/6.0* + quality contour lines).
-# Java 5.0.8 jar CI stays in build.yml (master) — do not merge jobs.
+# Java 5.0.8 jar CI stays in build.yml — scoped to legacy/java/** + workflow_dispatch only.
 # Q1: Allure results + generate + c8 coverage artifacts.
 # Q2: Sonar upload + sonar-gate-wait.
 # Q3: TestOps upload+close via allurectl (informational; skip without ALLURE_*).
@@ -33,7 +33,7 @@ on:
       - 'pnpm-workspace.yaml'
       - 'action.yml'
       - 'examples/github-actions/**'
-      - '.github/README.md'
+      - '.github/workflows/README.md'
       - '.github/actions/**'
       - '.github/examples/**'
       - '.github/workflows/action-e2e.yml'


### PR DESCRIPTION
## Summary

- Rename workflow to **CI — legacy Java 5.0.8** and scope triggers to `legacy/java/**`, `config/ci-telegram.json`, or `workflow_dispatch`.
- Docs/TS-only PRs no longer spawn Java 17/21/25 matrix builds.
- Fix stale `ci-6.0.yml` path filter after README move (`.github/workflows/README.md`).

## Context

Product line is **6.x TypeScript**. Java **5.0.8** stays frozen under `legacy/java/` ("keep forever; only explicit jar jobs") but should not block unrelated work. Current failures (`ChartConfigTest`) are pre-existing in legacy code, not caused by recent docs changes.

## Test plan

- [ ] Docs-only PR does not trigger `CI — legacy Java 5.0.8`.
- [ ] `gh workflow run` / edit under `legacy/java/**` still triggers the workflow.
- [ ] `workflow_dispatch` remains available for manual jar rebuild.


Made with [Cursor](https://cursor.com)